### PR TITLE
Allow general user registration and provision dashboards

### DIFF
--- a/backend/E-LearningDB.sql.sql
+++ b/backend/E-LearningDB.sql.sql
@@ -5,8 +5,15 @@ CREATE TABLE users (
   name VARCHAR(100) NOT NULL,
   email VARCHAR(100) UNIQUE NOT NULL,
   password_hash TEXT NOT NULL,
-  role ENUM('student', 'instructor') NOT NULL,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- DASHBOARDS TABLE
+CREATE TABLE dashboards (
+  dashboard_id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
 );
 
 -- CLASSES TABLE
@@ -136,10 +143,13 @@ CREATE TABLE live_lectures (
 );
 
 -- SAMPLE USERS
-INSERT INTO users (name, email, password_hash, role) VALUES
-('Musengwa Himoonga', 'musengwa@example.com', 'hashed_pw123', 'student'),
-('Grace Banda', 'grace@example.com', 'hashed_pw456', 'instructor'),
-('Webster Mwansa', 'webster@example.com', 'hashed_pw789', 'instructor');
+INSERT INTO users (name, email, password_hash) VALUES
+('Musengwa Himoonga', 'musengwa@example.com', 'hashed_pw123'),
+('Grace Banda', 'grace@example.com', 'hashed_pw456'),
+('Webster Mwansa', 'webster@example.com', 'hashed_pw789');
+
+-- SAMPLE DASHBOARDS
+INSERT INTO dashboards (user_id) VALUES (1), (2), (3);
 
 -- SAMPLE CLASS
 INSERT INTO classes (title, description, invite_code, instructor_id) VALUES

--- a/backend/routes/profile.js
+++ b/backend/routes/profile.js
@@ -29,7 +29,7 @@ function authenticateToken(req, res, next) {
 
 // Get profile of authenticated user
 router.get('/', authenticateToken, (req, res) => {
-    db.query('SELECT user_id, name, email, role, created_at FROM users WHERE user_id = ?', [req.user.user_id], (err, results) => {
+    db.query('SELECT user_id, name, email, created_at FROM users WHERE user_id = ?', [req.user.user_id], (err, results) => {
         if (err) return res.status(500).json({ message: 'Database error', error: err });
         if (results.length === 0) return res.status(404).json({ message: 'User not found.' });
         res.json(results[0]);

--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -5,20 +5,26 @@ const bcrypt = require('bcrypt');
 
 // Register a new user
 router.post('/register', async (req, res) => {
-    const { name, email, password, role } = req.body;
-    if (!name || !email || !password || !role) {
+    const { name, email, password } = req.body;
+    if (!name || !email || !password) {
         return res.status(400).json({ message: 'All fields are required.' });
     }
     try {
         const hash = await bcrypt.hash(password, 10);
-        db.query('INSERT INTO users (name, email, password_hash, role) VALUES (?, ?, ?, ?)', [name, email, hash, role], (err, result) => {
+        db.query('INSERT INTO users (name, email, password_hash) VALUES (?, ?, ?)', [name, email, hash], (err, result) => {
             if (err) {
                 if (err.code === 'ER_DUP_ENTRY') {
                     return res.status(409).json({ message: 'Email already exists.' });
                 }
                 return res.status(500).json({ message: 'Database error', error: err });
             }
-            res.status(201).json({ message: 'User registered successfully.' });
+            const userId = result.insertId;
+            db.query('INSERT INTO dashboards (user_id) VALUES (?)', [userId], (dashErr) => {
+                if (dashErr) {
+                    return res.status(500).json({ message: 'Dashboard creation failed', error: dashErr });
+                }
+                res.status(201).json({ message: 'User registered successfully.' });
+            });
         });
     } catch (err) {
         res.status(500).json({ message: 'Error hashing password', error: err });
@@ -27,7 +33,7 @@ router.post('/register', async (req, res) => {
 
 // Get all users (for demo)
 router.get('/', (req, res) => {
-    db.query('SELECT user_id, name, email, role, created_at FROM users', (err, results) => {
+    db.query('SELECT user_id, name, email, created_at FROM users', (err, results) => {
         if (err) return res.status(500).json({ message: 'Database error', error: err });
         res.json(results);
     });


### PR DESCRIPTION
## Summary
- remove user role from auth and profile flow
- create dashboard record when users register
- define dashboards table and update schema

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6893d820d82c83238b04411dc06f8b6f