### PR TITLE
feat: support role-free registration and class management

### DIFF
--- a/backend/routes/classes.js
+++ b/backend/routes/classes.js
@@ -1,0 +1,95 @@
+const express = require('express');
+const router = express.Router();
+const db = require('../config/db');
+const jwt = require('jsonwebtoken');
+require('dotenv').config();
+
+// Helper to run MySQL queries with promises
+function query(sql, params) {
+  return new Promise((resolve, reject) => {
+    db.query(sql, params, (err, results) => {
+      if (err) reject(err);
+      else resolve(results);
+    });
+  });
+}
+
+// Simple JWT authentication middleware
+function authenticateToken(req, res, next) {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
+  if (!token) return res.status(401).json({ message: 'No token provided.' });
+  jwt.verify(token, process.env.JWT_SECRET, (err, user) => {
+    if (err) return res.status(403).json({ message: 'Invalid token.' });
+    req.user = user;
+    next();
+  });
+}
+
+// Create a new class. Any authenticated user can create a class.
+router.post('/', authenticateToken, async (req, res) => {
+  const { title, description } = req.body;
+  if (!title) {
+    return res.status(400).json({ message: 'Title is required.' });
+  }
+  try {
+    // Generate a simple invite code
+    const inviteCode = Math.random().toString(36).substring(2, 8).toUpperCase();
+    await query(
+      'INSERT INTO classes (title, description, invite_code, instructor_id) VALUES (?, ?, ?, ?)',
+      [title, description, inviteCode, req.user.user_id]
+    );
+    res.status(201).json({ message: 'Class created successfully.', invite_code: inviteCode });
+  } catch (err) {
+    console.error('Create class error:', err);
+    res.status(500).json({ message: 'Server error', error: err });
+  }
+});
+
+// Join a class using an invite code. Any user may join.
+router.post('/join', authenticateToken, async (req, res) => {
+  const { inviteCode } = req.body;
+  if (!inviteCode) {
+    return res.status(400).json({ message: 'Invite code is required.' });
+  }
+  try {
+    const classes = await query('SELECT class_id FROM classes WHERE invite_code = ?', [inviteCode]);
+    if (classes.length === 0) {
+      return res.status(404).json({ message: 'Class not found.' });
+    }
+    const classId = classes[0].class_id;
+    // Insert enrollment if it does not already exist
+    await query(
+      'INSERT INTO enrollments (class_id, student_id, status) VALUES (?, ?, ?)',
+      [classId, req.user.user_id, 'approved']
+    );
+    res.json({ message: 'Joined class successfully.', class_id: classId });
+  } catch (err) {
+    console.error('Join class error:', err);
+    if (err.code === 'ER_DUP_ENTRY') {
+      return res.status(409).json({ message: 'Already enrolled in this class.' });
+    }
+    res.status(500).json({ message: 'Server error', error: err });
+  }
+});
+
+// Get classes for the current user (both created and joined)
+router.get('/mine', authenticateToken, async (req, res) => {
+  try {
+    const userId = req.user.user_id;
+    const classes = await query(
+      `SELECT DISTINCT c.class_id, c.title, c.description, c.invite_code
+       FROM classes c
+       LEFT JOIN enrollments e ON c.class_id = e.class_id AND e.student_id = ?
+       WHERE c.instructor_id = ? OR e.student_id = ?`,
+      [userId, userId, userId]
+    );
+    res.json(classes);
+  } catch (err) {
+    console.error('Get classes error:', err);
+    res.status(500).json({ message: 'Server error', error: err });
+  }
+});
+
+module.exports = router;
+

--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -3,15 +3,15 @@ const router = express.Router();
 const db = require('../config/db');
 const bcrypt = require('bcrypt');
 
-// Register a new user
+// Register a new user without requiring a role
 router.post('/register', async (req, res) => {
-    const { name, email, password, role } = req.body;
-    if (!name || !email || !password || !role) {
-        return res.status(400).json({ message: 'All fields are required.' });
+    const { name, email, password } = req.body;
+    if (!name || !email || !password) {
+        return res.status(400).json({ message: 'Name, email and password are required.' });
     }
     try {
         const hash = await bcrypt.hash(password, 10);
-        db.query('INSERT INTO users (name, email, password_hash, role) VALUES (?, ?, ?, ?)', [name, email, hash, role], (err, result) => {
+        db.query('INSERT INTO users (name, email, password_hash, role) VALUES (?, ?, ?, ?)', [name, email, hash, 'student'], (err, result) => {
             if (err) {
                 if (err.code === 'ER_DUP_ENTRY') {
                     return res.status(409).json({ message: 'Email already exists.' });

--- a/backend/server.js
+++ b/backend/server.js
@@ -9,6 +9,7 @@ const path = require('path'); // <-- ADD THIS LINE
 const userRoutes = require('./routes/user');
 const authRoutes = require('./routes/auth');
 const profileRoutes = require('./routes/profile');
+const classRoutes = require('./routes/classes');
 
 const app = express();
 app.use(cors());
@@ -26,6 +27,7 @@ app.get('/', (req, res) => {
 app.use('/api/user', userRoutes);
 app.use('/api/auth', authRoutes);
 app.use('/api/profile', profileRoutes);
+app.use('/api/classes', classRoutes);
 
 // Start server
 const PORT = process.env.PORT || 5000;

--- a/elearning-frontend/assets/js/main.js
+++ b/elearning-frontend/assets/js/main.js
@@ -1,0 +1,82 @@
+// Dashboard logic for creating/joining classes and showing user info
+document.addEventListener('DOMContentLoaded', () => {
+  const token = localStorage.getItem('userToken');
+  const user = JSON.parse(localStorage.getItem('userInfo') || '{}');
+
+  if (!token || !user.user_id) {
+    window.location.href = 'login.html';
+    return;
+  }
+
+  const welcomeEl = document.getElementById('welcomeMessage');
+  const classListEl = document.getElementById('classList');
+  const createForm = document.getElementById('createClassForm');
+  const joinForm = document.getElementById('joinClassForm');
+  const logoutBtn = document.getElementById('logout');
+
+  welcomeEl.textContent = `Welcome, ${user.name}!`;
+
+  logoutBtn.addEventListener('click', () => {
+    localStorage.removeItem('userToken');
+    localStorage.removeItem('userInfo');
+    window.location.href = 'login.html';
+  });
+
+  async function loadClasses() {
+    try {
+      const res = await fetch('http://localhost:5000/api/classes/mine', {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      const data = await res.json();
+      classListEl.innerHTML = '';
+      data.forEach(cls => {
+        const li = document.createElement('li');
+        li.textContent = `${cls.title} (${cls.invite_code})`;
+        classListEl.appendChild(li);
+      });
+    } catch (err) {
+      console.error('Load classes error', err);
+    }
+  }
+
+  createForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const title = document.getElementById('classTitle').value.trim();
+    const description = document.getElementById('classDescription').value.trim();
+    try {
+      await fetch('http://localhost:5000/api/classes', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify({ title, description })
+      });
+      createForm.reset();
+      loadClasses();
+    } catch (err) {
+      console.error('Create class error', err);
+    }
+  });
+
+  joinForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const inviteCode = document.getElementById('inviteCode').value.trim();
+    try {
+      await fetch('http://localhost:5000/api/classes/join', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify({ inviteCode })
+      });
+      joinForm.reset();
+      loadClasses();
+    } catch (err) {
+      console.error('Join class error', err);
+    }
+  });
+
+  loadClasses();
+});

--- a/elearning-frontend/assets/js/signup.js
+++ b/elearning-frontend/assets/js/signup.js
@@ -52,11 +52,32 @@ document.getElementById('signupForm').addEventListener('submit', function(e) {
     isValid = false;
   }
 
-  // If everything is valid, show message then redirect after 4s
+  // If everything is valid, send registration to backend
   if (isValid) {
-    successMessage.textContent = 'Account created! Redirecting to login…';
-    setTimeout(() => {
-      window.location.href = 'login.html';
-    }, 4000); // 4000ms = 4 seconds
+    fetch('http://localhost:5000/api/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: username.value.trim(),
+        email: email.value.trim(),
+        password: pwd
+      })
+    })
+      .then(res => res.json().then(data => ({ status: res.status, body: data })))
+      .then(({ status, body }) => {
+        if (status >= 400) throw new Error(body.message || 'Registration failed');
+        // Save token and user info so each user gets their own dashboard instance
+        if (body.token) {
+          localStorage.setItem('userToken', body.token);
+        }
+        if (body.user) {
+          localStorage.setItem('userInfo', JSON.stringify(body.user));
+        }
+        window.location.href = 'dashboard.html';
+      })
+      .catch(err => {
+        successMessage.textContent = err.message;
+        successMessage.style.color = 'red';
+      });
   }
 });

--- a/elearning-frontend/pages/dashboard.html
+++ b/elearning-frontend/pages/dashboard.html
@@ -17,15 +17,31 @@
     </header>
 
     <main>
-        <h2 id="welcomeMessage">Welcome, Student!</h2>
+        <h2 id="welcomeMessage">Welcome!</h2>
 
-        <div class="dashboard-grid">
-            <div class="card">My Classes</div>
-            <div class="card">Announcements</div>
-            <div class="card">Upcoming tasks and deadlines</div>
-        </div>
+        <section>
+            <h3>Create Class</h3>
+            <form id="createClassForm">
+                <input type="text" id="classTitle" placeholder="Class title" required>
+                <input type="text" id="classDescription" placeholder="Description">
+                <button type="submit">Create</button>
+            </form>
+        </section>
+
+        <section>
+            <h3>Join Class</h3>
+            <form id="joinClassForm">
+                <input type="text" id="inviteCode" placeholder="Invite code" required>
+                <button type="submit">Join</button>
+            </form>
+        </section>
+
+        <section>
+            <h3>My Classes</h3>
+            <ul id="classList"></ul>
+        </section>
     </main>
 
-    <script src="js/main.js"></script>
+    <script src="../assets/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow user registration without selecting a role and return auth token
- add class routes so any user can create or join classes
- build user-specific dashboard that shows and manages classes

## Testing
- `cd backend && npm test` *(fails: Missing script "test"*

------
https://chatgpt.com/codex/tasks/task_e_6893da9179408323899776741271c243