### PR TITLE
Refactor registration to be role-agnostic and add user dashboards

### DIFF
--- a/backend/E-LearningDB.sql.sql
+++ b/backend/E-LearningDB.sql.sql
@@ -5,8 +5,15 @@ CREATE TABLE users (
   name VARCHAR(100) NOT NULL,
   email VARCHAR(100) UNIQUE NOT NULL,
   password_hash TEXT NOT NULL,
-  role ENUM('student', 'instructor') NOT NULL,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- DASHBOARDS TABLE
+CREATE TABLE dashboards (
+  dashboard_id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT UNIQUE,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
 );
 
 -- CLASSES TABLE
@@ -136,10 +143,13 @@ CREATE TABLE live_lectures (
 );
 
 -- SAMPLE USERS
-INSERT INTO users (name, email, password_hash, role) VALUES
-('Musengwa Himoonga', 'musengwa@example.com', 'hashed_pw123', 'student'),
-('Grace Banda', 'grace@example.com', 'hashed_pw456', 'instructor'),
-('Webster Mwansa', 'webster@example.com', 'hashed_pw789', 'instructor');
+INSERT INTO users (name, email, password_hash) VALUES
+('Musengwa Himoonga', 'musengwa@example.com', 'hashed_pw123'),
+('Grace Banda', 'grace@example.com', 'hashed_pw456'),
+('Webster Mwansa', 'webster@example.com', 'hashed_pw789');
+
+-- SAMPLE DASHBOARDS
+INSERT INTO dashboards (user_id) VALUES (1), (2), (3);
 
 -- SAMPLE CLASS
 INSERT INTO classes (title, description, invite_code, instructor_id) VALUES

--- a/backend/routes/profile.js
+++ b/backend/routes/profile.js
@@ -17,23 +17,23 @@ function query(sql, params) {
 
 // Middleware to verify JWT
 function authenticateToken(req, res, next) {
-    const authHeader = req.headers['authorization'];
-    const token = authHeader && authHeader.split(' ')[1];
-    if (!token) return res.status(401).json({ message: 'No token provided.' });
-    jwt.verify(token, process.env.JWT_SECRET, (err, user) => {
-        if (err) return res.status(403).json({ message: 'Invalid token.' });
-        req.user = user;
-        next();
-    });
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
+  if (!token) return res.status(401).json({ message: 'No token provided.' });
+  jwt.verify(token, process.env.JWT_SECRET, (err, user) => {
+    if (err) return res.status(403).json({ message: 'Invalid token.' });
+    req.user = user;
+    next();
+  });
 }
 
 // Get profile of authenticated user
 router.get('/', authenticateToken, (req, res) => {
-    db.query('SELECT user_id, name, email, role, created_at FROM users WHERE user_id = ?', [req.user.user_id], (err, results) => {
-        if (err) return res.status(500).json({ message: 'Database error', error: err });
-        if (results.length === 0) return res.status(404).json({ message: 'User not found.' });
-        res.json(results[0]);
-    });
+  db.query('SELECT user_id, name, email, created_at FROM users WHERE user_id = ?', [req.user.user_id], (err, results) => {
+    if (err) return res.status(500).json({ message: 'Database error', error: err });
+    if (results.length === 0) return res.status(404).json({ message: 'User not found.' });
+    res.json(results[0]);
+  });
 });
 
 // Update basic profile information for the authenticated user
@@ -87,4 +87,5 @@ router.put('/password', authenticateToken, async (req, res) => {
   }
 });
 
-module.exports = router; 
+module.exports = router;
+

--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -5,32 +5,34 @@ const bcrypt = require('bcrypt');
 
 // Register a new user
 router.post('/register', async (req, res) => {
-    const { name, email, password, role } = req.body;
-    if (!name || !email || !password || !role) {
-        return res.status(400).json({ message: 'All fields are required.' });
-    }
-    try {
-        const hash = await bcrypt.hash(password, 10);
-        db.query('INSERT INTO users (name, email, password_hash, role) VALUES (?, ?, ?, ?)', [name, email, hash, role], (err, result) => {
-            if (err) {
-                if (err.code === 'ER_DUP_ENTRY') {
-                    return res.status(409).json({ message: 'Email already exists.' });
-                }
-                return res.status(500).json({ message: 'Database error', error: err });
-            }
-            res.status(201).json({ message: 'User registered successfully.' });
-        });
-    } catch (err) {
-        res.status(500).json({ message: 'Error hashing password', error: err });
-    }
+  const { name, email, password } = req.body;
+  if (!name || !email || !password) {
+    return res.status(400).json({ message: 'All fields are required.' });
+  }
+  try {
+    const hash = await bcrypt.hash(password, 10);
+    db.query('INSERT INTO users (name, email, password_hash) VALUES (?, ?, ?)', [name, email, hash], (err, result) => {
+      if (err) {
+        if (err.code === 'ER_DUP_ENTRY') {
+          return res.status(409).json({ message: 'Email already exists.' });
+        }
+        return res.status(500).json({ message: 'Database error', error: err });
+      }
+      db.query('INSERT INTO dashboards (user_id) VALUES (?)', [result.insertId]);
+      res.status(201).json({ message: 'User registered successfully.' });
+    });
+  } catch (err) {
+    res.status(500).json({ message: 'Error hashing password', error: err });
+  }
 });
 
 // Get all users (for demo)
 router.get('/', (req, res) => {
-    db.query('SELECT user_id, name, email, role, created_at FROM users', (err, results) => {
-        if (err) return res.status(500).json({ message: 'Database error', error: err });
-        res.json(results);
-    });
+  db.query('SELECT user_id, name, email, created_at FROM users', (err, results) => {
+    if (err) return res.status(500).json({ message: 'Database error', error: err });
+    res.json(results);
+  });
 });
 
-module.exports = router; 
+module.exports = router;
+

--- a/elearning-frontend/assets/js/signup.js
+++ b/elearning-frontend/assets/js/signup.js
@@ -1,4 +1,4 @@
-document.getElementById('signupForm').addEventListener('submit', function(e) {
+document.getElementById('signupForm').addEventListener('submit', async function(e) {
   e.preventDefault(); // stop form from submitting
 
   // grab form fields
@@ -52,11 +52,29 @@ document.getElementById('signupForm').addEventListener('submit', function(e) {
     isValid = false;
   }
 
-  // If everything is valid, show message then redirect after 4s
+  // If everything is valid, submit to backend then redirect
   if (isValid) {
-    successMessage.textContent = 'Account created! Redirecting to login…';
-    setTimeout(() => {
-      window.location.href = 'login.html';
-    }, 4000); // 4000ms = 4 seconds
+    try {
+      const response = await fetch('http://localhost:5000/api/auth/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: username.value.trim(),
+          email: email.value.trim(),
+          password: pwd
+        })
+      });
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data.message || 'Registration failed. Please try again.');
+      }
+      successMessage.textContent = data.message || 'Account created! Redirecting to login…';
+      setTimeout(() => {
+        window.location.href = 'login.html';
+      }, 4000);
+    } catch (err) {
+      emailError.textContent = err.message;
+    }
   }
 });
+


### PR DESCRIPTION
## Summary
- remove role-based logic from auth, user, and profile routes
- add dashboards table and generate dashboards on registration
- update frontend signup to use new registration flow

## Testing
- `npm test` (fails: Missing script: "test")


------
https://chatgpt.com/codex/tasks/task_e_6893dd75aec08323972941320d0fac19