### PR TITLE
feat: add class join and create modals

### DIFF
--- a/elearning-frontend/assets/css/dashboard.css
+++ b/elearning-frontend/assets/css/dashboard.css
@@ -121,3 +121,54 @@ button:hover {
     background-color: #d97706;
     transform: translateY(-3px);
 }
+
+/* Modal Styles */
+.modal {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.modal.active {
+    display: flex;
+}
+
+.modal-content {
+    background: #ffffff;
+    padding: 30px;
+    border-radius: 8px;
+    width: 90%;
+    max-width: 400px;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+    position: relative;
+}
+
+.modal-content h3 {
+    margin-top: 0;
+}
+
+.modal-content input,
+.modal-content textarea {
+    width: 100%;
+    margin-bottom: 15px;
+    padding: 10px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 16px;
+    resize: vertical;
+}
+
+.modal-content .close {
+    position: absolute;
+    top: 10px;
+    right: 15px;
+    font-size: 20px;
+    cursor: pointer;
+}

--- a/elearning-frontend/assets/js/navigation.js
+++ b/elearning-frontend/assets/js/navigation.js
@@ -1,0 +1,76 @@
+// Handle join and create class actions
+
+document.addEventListener('DOMContentLoaded', () => {
+  const joinBtn = document.getElementById('openJoin');
+  const createBtn = document.getElementById('openCreate');
+  const joinModal = document.getElementById('joinModal');
+  const createModal = document.getElementById('createModal');
+  const closeButtons = document.querySelectorAll('.close');
+
+  // Open modals
+  joinBtn.addEventListener('click', () => joinModal.classList.add('active'));
+  createBtn.addEventListener('click', () => createModal.classList.add('active'));
+
+  // Close modals
+  closeButtons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const id = btn.getAttribute('data-close');
+      document.getElementById(id).classList.remove('active');
+    });
+  });
+
+  // Join class form
+  document.getElementById('joinForm').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const code = document.getElementById('classCode').value.trim();
+    const token = localStorage.getItem('userToken');
+    if (!token) {
+      alert('You must be logged in to join a class.');
+      return;
+    }
+    try {
+      const res = await fetch('http://localhost:5000/api/classes/join', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`
+        },
+        body: JSON.stringify({ invite_code: code })
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.message || 'Failed to join class');
+      alert('Request to join class sent successfully.');
+      window.location.href = 'dashboard.html';
+    } catch (err) {
+      alert(err.message);
+    }
+  });
+
+  // Create class form
+  document.getElementById('createForm').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const title = document.getElementById('classTitle').value.trim();
+    const description = document.getElementById('classDescription').value.trim();
+    const token = localStorage.getItem('userToken');
+    if (!token) {
+      alert('You must be logged in to create a class.');
+      return;
+    }
+    try {
+      const res = await fetch('http://localhost:5000/api/classes', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`
+        },
+        body: JSON.stringify({ title, description })
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.message || 'Failed to create class');
+      alert('Class created successfully.');
+      window.location.href = 'dashboard.html';
+    } catch (err) {
+      alert(err.message);
+    }
+  });
+});

--- a/elearning-frontend/pages/navigation.html
+++ b/elearning-frontend/pages/navigation.html
@@ -18,11 +18,36 @@
     <main class="nav-main">
         <h2>Choose an Option</h2>
         <div class="button-container">
-            <button class="nav-btn">Join Class</button>
-            <button class="nav-btn">Create Class</button>
+            <button class="nav-btn" id="openJoin">Join Class</button>
+            <button class="nav-btn" id="openCreate">Create Class</button>
         </div>
     </main>
 
-    <script src="js/main.js"></script>
+    <!-- Join Class Modal -->
+    <div id="joinModal" class="modal">
+        <div class="modal-content">
+            <span class="close" data-close="joinModal">&times;</span>
+            <h3>Join Class</h3>
+            <form id="joinForm">
+                <input type="text" id="classCode" placeholder="Class code" required>
+                <button type="submit">Join</button>
+            </form>
+        </div>
+    </div>
+
+    <!-- Create Class Modal -->
+    <div id="createModal" class="modal">
+        <div class="modal-content">
+            <span class="close" data-close="createModal">&times;</span>
+            <h3>Create Class</h3>
+            <form id="createForm">
+                <input type="text" id="classTitle" placeholder="Title" required>
+                <textarea id="classDescription" placeholder="Description" required></textarea>
+                <button type="submit">Create</button>
+            </form>
+        </div>
+    </div>
+
+    <script src="../assets/js/navigation.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add join and create class modals on navigation page
- handle class creation and enrollment requests via API
- style modal components for cohesive appearance

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6893e3d925e083239020c7dc5e26c44d