### PR TITLE
Show created classes with codes on dashboard

### DIFF
--- a/elearning-frontend/assets/js/main.js
+++ b/elearning-frontend/assets/js/main.js
@@ -1,0 +1,51 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  const token = localStorage.getItem('userToken');
+  const userInfo = JSON.parse(localStorage.getItem('userInfo') || '{}');
+  const welcome = document.getElementById('welcomeMessage');
+  if (userInfo.name && welcome) {
+    welcome.textContent = `Welcome, ${userInfo.name}!`;
+  }
+
+  // Redirect to login if no token
+  if (!token) {
+    window.location.href = 'login.html';
+    return;
+  }
+
+  const list = document.getElementById('classesList');
+  try {
+    const res = await fetch('http://localhost:5000/api/classes', {
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.message || 'Failed to load classes');
+
+    if (data.length === 0) {
+      const li = document.createElement('li');
+      li.textContent = 'No classes found.';
+      list.appendChild(li);
+    } else {
+      data.forEach(cls => {
+        const li = document.createElement('li');
+        li.textContent = `${cls.title} (Code: ${cls.invite_code})`;
+        list.appendChild(li);
+      });
+    }
+  } catch (err) {
+    const li = document.createElement('li');
+    li.textContent = err.message;
+    list.appendChild(li);
+  }
+
+  const logout = document.getElementById('logout');
+  if (logout) {
+    logout.addEventListener('click', (e) => {
+      e.preventDefault();
+      localStorage.removeItem('userToken');
+      localStorage.removeItem('userInfo');
+      window.location.href = 'login.html';
+    });
+  }
+});

--- a/elearning-frontend/pages/dashboard.html
+++ b/elearning-frontend/pages/dashboard.html
@@ -20,12 +20,15 @@
         <h2 id="welcomeMessage">Welcome, Student!</h2>
 
         <div class="dashboard-grid">
-            <div class="card">My Classes</div>
+            <div class="card">
+                <h3>My Classes</h3>
+                <ul id="classesList"></ul>
+            </div>
             <div class="card">Announcements</div>
             <div class="card">Upcoming tasks and deadlines</div>
         </div>
     </main>
 
-    <script src="js/main.js"></script>
+    <script src="../assets/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add backend endpoint to fetch logged-in user's classes
- display class titles and invite codes on dashboard
- fix dashboard script path and render class list

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6893e69edb988323aa77d8ece3136f02