### PR TITLE
feat: add course material management

### DIFF
--- a/backend/E-LearningDB.sql.sql
+++ b/backend/E-LearningDB.sql.sql
@@ -44,6 +44,7 @@ CREATE TABLE materials (
   class_id INT,
   title VARCHAR(255),
   file_url TEXT,
+  folder VARCHAR(255),
   tags TEXT,
   uploaded_by INT,
   uploaded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -160,8 +161,8 @@ INSERT INTO enrollments (class_id, student_id, status) VALUES
 (1, 1, 'approved');
 
 -- SAMPLE MATERIAL
-INSERT INTO materials (class_id, title, file_url, tags, uploaded_by) VALUES
-(1, 'Week 1 Slides', 'materials/week1.pdf', 'intro,web', 2);
+INSERT INTO materials (class_id, title, file_url, folder, tags, uploaded_by) VALUES
+(1, 'Week 1 Slides', 'materials/week1.pdf', 'Week 1', 'intro,web', 2);
 
 -- SAMPLE ASSIGNMENT
 INSERT INTO assignments (class_id, title, description, due_date) VALUES

--- a/backend/routes/materials.js
+++ b/backend/routes/materials.js
@@ -1,0 +1,87 @@
+const express = require('express');
+const router = express.Router();
+const db = require('../config/db');
+const fs = require('fs');
+const path = require('path');
+
+const uploadDir = path.join(__dirname, '../uploads');
+if (!fs.existsSync(uploadDir)) {
+  fs.mkdirSync(uploadDir);
+}
+
+// List materials for a class with optional folder filter
+router.get('/class/:classId', (req, res) => {
+  const classId = req.params.classId;
+  const { folder } = req.query;
+  let sql = 'SELECT * FROM materials WHERE class_id = ?';
+  const params = [classId];
+  if (folder) {
+    sql += ' AND folder = ?';
+    params.push(folder);
+  }
+  db.query(sql, params, (err, results) => {
+    if (err) return res.status(500).json({ message: 'Database error', error: err });
+    res.json(results);
+  });
+});
+
+// Upload new material
+router.post('/class/:classId', (req, res) => {
+  const classId = req.params.classId;
+  const { title, tags, folder, uploaded_by, fileName, fileData } = req.body;
+  if (!fileName || !fileData) {
+    return res.status(400).json({ message: 'File data is required' });
+  }
+  const buffer = Buffer.from(fileData, 'base64');
+  const storedName = `${Date.now()}-${fileName}`;
+  const filePath = path.join(uploadDir, storedName);
+  fs.writeFile(filePath, buffer, (err) => {
+    if (err) return res.status(500).json({ message: 'File save error', error: err });
+    const fileUrl = `/uploads/${storedName}`;
+    const sql = 'INSERT INTO materials (class_id, title, file_url, folder, tags, uploaded_by) VALUES (?, ?, ?, ?, ?, ?)';
+    db.query(sql, [classId, title, fileUrl, folder, tags, uploaded_by], (err, result) => {
+      if (err) return res.status(500).json({ message: 'Database error', error: err });
+      res.json({ material_id: result.insertId, file_url: fileUrl });
+    });
+  });
+});
+
+// Update material metadata
+router.put('/:materialId', (req, res) => {
+  const materialId = req.params.materialId;
+  const { title, tags, folder, fileName, fileData } = req.body;
+  const params = [title, tags, folder];
+  let sql = 'UPDATE materials SET title = ?, tags = ?, folder = ?';
+  if (fileName && fileData) {
+    const buffer = Buffer.from(fileData, 'base64');
+    const storedName = `${Date.now()}-${fileName}`;
+    const filePath = path.join(uploadDir, storedName);
+    fs.writeFileSync(filePath, buffer);
+    sql += ', file_url = ?';
+    params.push(`/uploads/${storedName}`);
+  }
+  sql += ' WHERE material_id = ?';
+  params.push(materialId);
+  db.query(sql, params, (err) => {
+    if (err) return res.status(500).json({ message: 'Database error', error: err });
+    res.json({ message: 'Material updated' });
+  });
+});
+
+// Delete material
+router.delete('/:materialId', (req, res) => {
+  const materialId = req.params.materialId;
+  db.query('SELECT file_url FROM materials WHERE material_id = ?', [materialId], (err, results) => {
+    if (err) return res.status(500).json({ message: 'Database error', error: err });
+    if (results.length === 0) return res.status(404).json({ message: 'Material not found' });
+    const fileUrl = results[0].file_url;
+    const filePath = path.join(__dirname, '..', fileUrl);
+    fs.unlink(filePath, () => { /* ignore errors */ });
+    db.query('DELETE FROM materials WHERE material_id = ?', [materialId], (err2) => {
+      if (err2) return res.status(500).json({ message: 'Database error', error: err2 });
+      res.json({ message: 'Material deleted' });
+    });
+  });
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -10,6 +10,7 @@ const userRoutes = require('./routes/user');
 const authRoutes = require('./routes/auth');
 const profileRoutes = require('./routes/profile');
 const classRoutes = require('./routes/classes');
+const materialRoutes = require('./routes/materials');
 
 const app = express();
 app.use(cors());
@@ -17,6 +18,7 @@ app.use(express.json());
 
 // Serve static files
 app.use(express.static(path.join(__dirname, '../elearning-frontend')));
+app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
 
 // Serve the welcome page for "/"
 app.get('/', (req, res) => {
@@ -28,6 +30,7 @@ app.use('/api/user', userRoutes);
 app.use('/api/auth', authRoutes);
 app.use('/api/profile', profileRoutes);
 app.use('/api/classes', classRoutes);
+app.use('/api/materials', materialRoutes);
 
 // Start server
 const PORT = process.env.PORT || 5000;

--- a/elearning-frontend/assets/css/materials.css
+++ b/elearning-frontend/assets/css/materials.css
@@ -1,0 +1,107 @@
+/* Materials page styling */
+.materials-header {
+  background: linear-gradient(135deg, #1f2937, #0f172a);
+  color: #f8fafc;
+  text-align: center;
+  padding: 30px 0;
+}
+.materials-header h2 {
+  font-size: 2rem;
+  color: #f59e0b;
+  margin: 0;
+}
+
+.upload-section,
+.materials-list {
+  background: #ffffff;
+  max-width: 900px;
+  margin: 25px auto;
+  padding: 25px;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+}
+
+.upload-section h3,
+.materials-list h3 {
+  font-size: 1.4rem;
+  color: #1f2937;
+  margin-bottom: 15px;
+}
+
+#uploadForm input[type="text"],
+#uploadForm input[type="file"] {
+  width: 100%;
+  padding: 10px;
+  margin-bottom: 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  font-size: 1rem;
+}
+
+#uploadForm button {
+  background-color: #f59e0b;
+  color: #fff;
+  border: none;
+  padding: 10px 20px;
+  font-size: 1rem;
+  font-weight: 600;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+#uploadForm button:hover {
+  background-color: #d97706;
+}
+
+.folder-section {
+  margin-top: 25px;
+}
+.folder-section h4 {
+  font-size: 1.3rem;
+  color: #0f172a;
+  margin-bottom: 10px;
+  border-bottom: 2px solid #f59e0b;
+  padding-bottom: 5px;
+}
+
+.material-card {
+  display: flex;
+  flex-direction: column;
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  padding: 15px;
+  margin-bottom: 12px;
+}
+.material-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #1f2937;
+  margin-bottom: 8px;
+}
+.tag {
+  display: inline-block;
+  background-color: #0ea5e9;
+  color: white;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  margin-right: 5px;
+}
+.download-link {
+  color: #2563eb;
+  text-decoration: none;
+  font-size: 0.9rem;
+  margin-top: 8px;
+}
+.download-link:hover {
+  text-decoration: underline;
+}
+.card-actions {
+  margin-top: 10px;
+}
+.card-actions button {
+  margin-right: 8px;
+  font-size: 0.85rem;
+  padding: 6px 12px;
+}

--- a/elearning-frontend/assets/js/materials.js
+++ b/elearning-frontend/assets/js/materials.js
@@ -1,0 +1,119 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const classId = new URLSearchParams(window.location.search).get('classId') || 1;
+  const uploadForm = document.getElementById('uploadForm');
+  const materialsContainer = document.getElementById('materialsContainer');
+
+  async function loadMaterials() {
+    materialsContainer.innerHTML = '';
+    try {
+      const res = await fetch(`http://localhost:5000/api/materials/class/${classId}`);
+      const data = await res.json();
+      const grouped = {};
+      data.forEach(m => {
+        const folder = m.folder || 'General';
+        if (!grouped[folder]) grouped[folder] = [];
+        grouped[folder].push(m);
+      });
+      Object.keys(grouped).forEach(folder => {
+        const section = document.createElement('div');
+        section.classList.add('folder-section');
+        const h4 = document.createElement('h4');
+        h4.textContent = folder;
+        section.appendChild(h4);
+        grouped[folder].forEach(mat => {
+          const card = document.createElement('div');
+          card.classList.add('material-card');
+
+          const title = document.createElement('span');
+          title.classList.add('material-title');
+          title.textContent = mat.title;
+          card.appendChild(title);
+
+          if (mat.tags) {
+            const tagsDiv = document.createElement('div');
+            mat.tags.split(',').forEach(t => {
+              const tag = document.createElement('span');
+              tag.classList.add('tag');
+              tag.textContent = t.trim();
+              tagsDiv.appendChild(tag);
+            });
+            card.appendChild(tagsDiv);
+          }
+
+          const link = document.createElement('a');
+          const url = mat.file_url.startsWith('http') ? mat.file_url : `http://localhost:5000${mat.file_url}`;
+          link.href = url;
+          link.textContent = 'Download';
+          link.classList.add('download-link');
+          card.appendChild(link);
+
+          const actions = document.createElement('div');
+          actions.classList.add('card-actions');
+          const editBtn = document.createElement('button');
+          editBtn.textContent = 'Edit';
+          editBtn.addEventListener('click', () => editMaterial(mat));
+          const delBtn = document.createElement('button');
+          delBtn.textContent = 'Delete';
+          delBtn.addEventListener('click', () => deleteMaterial(mat.material_id));
+          actions.appendChild(editBtn);
+          actions.appendChild(delBtn);
+          card.appendChild(actions);
+
+          section.appendChild(card);
+        });
+        materialsContainer.appendChild(section);
+      });
+    } catch (err) {
+      materialsContainer.textContent = 'Failed to load materials.';
+    }
+  }
+
+  uploadForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const fileInput = document.getElementById('file');
+    const file = fileInput.files[0];
+    const reader = new FileReader();
+    reader.onload = async () => {
+      const base64 = reader.result.split(',')[1];
+      const body = {
+        title: uploadForm.title.value,
+        folder: uploadForm.folder.value,
+        tags: uploadForm.tags.value,
+        uploaded_by: 1,
+        fileName: file.name,
+        fileData: base64
+      };
+      await fetch(`http://localhost:5000/api/materials/class/${classId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      });
+      uploadForm.reset();
+      loadMaterials();
+    };
+    reader.readAsDataURL(file);
+  });
+
+  async function deleteMaterial(id) {
+    if (!confirm('Delete this material?')) return;
+    await fetch(`http://localhost:5000/api/materials/${id}`, { method: 'DELETE' });
+    loadMaterials();
+  }
+
+  async function editMaterial(mat) {
+    const newTitle = prompt('Title', mat.title);
+    if (newTitle === null) return;
+    const newFolder = prompt('Folder', mat.folder || '');
+    if (newFolder === null) return;
+    const newTags = prompt('Tags', mat.tags || '');
+    if (newTags === null) return;
+    await fetch(`http://localhost:5000/api/materials/${mat.material_id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: newTitle, folder: newFolder, tags: newTags })
+    });
+    loadMaterials();
+  }
+
+  loadMaterials();
+});

--- a/elearning-frontend/assets/js/navigation.js
+++ b/elearning-frontend/assets/js/navigation.js
@@ -3,6 +3,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const joinBtn = document.getElementById('openJoin');
   const createBtn = document.getElementById('openCreate');
+  const materialsBtn = document.getElementById('openMaterials');
   const joinModal = document.getElementById('joinModal');
   const createModal = document.getElementById('createModal');
   const closeButtons = document.querySelectorAll('.close');
@@ -10,6 +11,9 @@ document.addEventListener('DOMContentLoaded', () => {
   // Open modals
   joinBtn.addEventListener('click', () => joinModal.classList.add('active'));
   createBtn.addEventListener('click', () => createModal.classList.add('active'));
+  materialsBtn.addEventListener('click', () => {
+    window.location.href = 'materials.html?classId=1';
+  });
 
   // Close modals
   closeButtons.forEach(btn => {

--- a/elearning-frontend/pages/materials.html
+++ b/elearning-frontend/pages/materials.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Course Materials</title>
+    <link rel="stylesheet" href="../assets/css/dashboard.css">
+    <link rel="stylesheet" href="../assets/css/materials.css">
+</head>
+<body>
+    <header class="header">
+        <div class="logo">eLearnHub</div>
+        <nav>
+            <a href="navigation.html">Navigation</a>
+            <a href="#" id="logout">Logout</a>
+        </nav>
+    </header>
+
+    <section class="materials-header">
+        <h2>Course Materials</h2>
+    </section>
+
+    <main>
+        <div class="upload-section">
+            <h3>Upload Material</h3>
+            <form id="uploadForm">
+                <input type="text" name="title" id="title" placeholder="Title" required>
+                <input type="text" name="folder" id="folder" placeholder="Folder (e.g. Week 1)">
+                <input type="text" name="tags" id="tags" placeholder="Tags (comma separated)">
+                <input type="file" name="file" id="file" required>
+                <button type="submit">Upload</button>
+            </form>
+        </div>
+
+        <div class="materials-list">
+            <h3>Available Materials</h3>
+            <div id="materialsContainer"></div>
+        </div>
+    </main>
+
+    <script src="../assets/js/materials.js"></script>
+</body>
+</html>

--- a/elearning-frontend/pages/navigation.html
+++ b/elearning-frontend/pages/navigation.html
@@ -20,6 +20,7 @@
         <div class="button-container">
             <button class="nav-btn" id="openJoin">Join Class</button>
             <button class="nav-btn" id="openCreate">Create Class</button>
+            <button class="nav-btn" id="openMaterials">Course Materials</button>
         </div>
     </main>
 


### PR DESCRIPTION
## Summary
- add database schema and API routes for managing course materials
- build materials page with colorful, accessible UI for uploads and organization
- link materials management from navigation for quick access

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6893edba8ffc8323b2dadd9732d1e99e