### PR TITLE
feat: add course selection for materials

### DIFF
--- a/elearning-frontend/assets/css/materials.css
+++ b/elearning-frontend/assets/css/materials.css
@@ -21,6 +21,15 @@
   box-shadow: 0 2px 8px rgba(0,0,0,0.06);
 }
 
+.course-selector {
+  background: #ffffff;
+  max-width: 900px;
+  margin: 25px auto;
+  padding: 25px;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+}
+
 .upload-section h3,
 .materials-list h3 {
   font-size: 1.4rem;

--- a/elearning-frontend/assets/js/navigation.js
+++ b/elearning-frontend/assets/js/navigation.js
@@ -12,7 +12,7 @@ document.addEventListener('DOMContentLoaded', () => {
   joinBtn.addEventListener('click', () => joinModal.classList.add('active'));
   createBtn.addEventListener('click', () => createModal.classList.add('active'));
   materialsBtn.addEventListener('click', () => {
-    window.location.href = 'materials.html?classId=1';
+    window.location.href = 'materials.html';
   });
 
   // Close modals

--- a/elearning-frontend/pages/materials.html
+++ b/elearning-frontend/pages/materials.html
@@ -21,7 +21,14 @@
     </section>
 
     <main>
-        <div class="upload-section">
+        <div class="course-selector">
+            <label for="courseSelect">Select Course:</label>
+            <select id="courseSelect">
+                <option value="">-- Choose a Course --</option>
+            </select>
+        </div>
+
+        <div class="upload-section" style="display: none;">
             <h3>Upload Material</h3>
             <form id="uploadForm">
                 <input type="text" name="title" id="title" placeholder="Title" required>
@@ -32,7 +39,7 @@
             </form>
         </div>
 
-        <div class="materials-list">
+        <div class="materials-list" style="display: none;">
             <h3>Available Materials</h3>
             <div id="materialsContainer"></div>
         </div>


### PR DESCRIPTION
## Summary
- Add course selector to materials page to show courses before listing materials or uploads
- Load user courses in materials script and toggle materials for selected course
- Direct navigation link to materials page without preset class

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6893f0f2eb9483238c838b403232c180