### PR TITLE
Improve material upload handling

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -14,7 +14,9 @@ const materialRoutes = require('./routes/materials');
 
 const app = express();
 app.use(cors());
-app.use(express.json());
+// Increase payload limits to allow larger file uploads encoded in JSON
+app.use(express.json({ limit: '50mb' }));
+app.use(express.urlencoded({ extended: true, limit: '50mb' }));
 
 // Serve static files
 app.use(express.static(path.join(__dirname, '../elearning-frontend')));

--- a/elearning-frontend/assets/js/materials.js
+++ b/elearning-frontend/assets/js/materials.js
@@ -121,13 +121,25 @@ document.addEventListener('DOMContentLoaded', () => {
         fileName: file.name,
         fileData: base64
       };
-      await fetch(`http://localhost:5000/api/materials/class/${selectedClassId}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body)
-      });
-      uploadForm.reset();
-      loadMaterials();
+      try {
+        const res = await fetch(`http://localhost:5000/api/materials/class/${selectedClassId}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body)
+        });
+        if (!res.ok) {
+          const errText = await res.text();
+          throw new Error(errText || 'Upload failed');
+        }
+        alert('Upload successful');
+        uploadForm.reset();
+        loadMaterials();
+      } catch (err) {
+        alert('Upload failed: ' + err.message);
+      }
+    };
+    reader.onerror = () => {
+      alert('Unable to read file');
     };
     reader.readAsDataURL(file);
   });


### PR DESCRIPTION
## Summary
- allow larger JSON payloads for file uploads
- surface success and error feedback when uploading materials

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6893f8a7d6e48323a05caebb3d7088c7