### PR TITLE
Add assignment management features

### DIFF
--- a/backend/routes/assignments.js
+++ b/backend/routes/assignments.js
@@ -1,0 +1,249 @@
+const express = require('express');
+const router = express.Router();
+const db = require('../config/db');
+const jwt = require('jsonwebtoken');
+const fs = require('fs');
+const path = require('path');
+require('dotenv').config();
+
+// Directory for assignment submissions
+const submissionDir = path.join(__dirname, '../uploads/submissions');
+if (!fs.existsSync(submissionDir)) {
+  fs.mkdirSync(submissionDir, { recursive: true });
+}
+
+// Utility helper to use async/await with db queries
+function query(sql, params) {
+  return new Promise((resolve, reject) => {
+    db.query(sql, params, (err, results) => {
+      if (err) reject(err);
+      else resolve(results);
+    });
+  });
+}
+
+// Middleware to verify JWT
+function authenticateToken(req, res, next) {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
+  if (!token) return res.status(401).json({ message: 'No token provided.' });
+  jwt.verify(token, process.env.JWT_SECRET, (err, user) => {
+    if (err) return res.status(403).json({ message: 'Invalid token.' });
+    req.user = user;
+    next();
+  });
+}
+
+// Fetch assignments for a class and indicate if requester is instructor
+router.get('/class/:classId', authenticateToken, async (req, res) => {
+  const { classId } = req.params;
+  try {
+    const classes = await query('SELECT instructor_id FROM classes WHERE class_id = ?', [classId]);
+    if (classes.length === 0) {
+      return res.status(404).json({ message: 'Class not found.' });
+    }
+    const isInstructor = classes[0].instructor_id === req.user.user_id;
+    if (!isInstructor) {
+      const enrolled = await query(
+        "SELECT enrollment_id FROM enrollments WHERE class_id = ? AND student_id = ? AND status = 'approved'",
+        [classId, req.user.user_id]
+      );
+      if (enrolled.length === 0) {
+        return res.status(403).json({ message: 'Not authorized to view assignments for this class.' });
+      }
+    }
+
+    const assignments = await query(
+      `SELECT a.assignment_id, a.title, a.description, a.due_date,
+              s.submission_id, g.score, g.feedback
+         FROM assignments a
+         LEFT JOIN submissions s ON a.assignment_id = s.assignment_id AND s.student_id = ?
+         LEFT JOIN grades g ON s.submission_id = g.submission_id
+        WHERE a.class_id = ?`,
+      [req.user.user_id, classId]
+    );
+
+    res.json({ is_instructor: isInstructor, assignments });
+  } catch (err) {
+    console.error('Fetch assignments error:', err);
+    res.status(500).json({ message: 'Server error', error: err });
+  }
+});
+
+// Create assignment
+router.post('/class/:classId', authenticateToken, async (req, res) => {
+  const { classId } = req.params;
+  const { title, description, due_date } = req.body;
+  if (!title) {
+    return res.status(400).json({ message: 'Title is required.' });
+  }
+  try {
+    const classes = await query('SELECT instructor_id FROM classes WHERE class_id = ?', [classId]);
+    if (classes.length === 0 || classes[0].instructor_id !== req.user.user_id) {
+      return res.status(403).json({ message: 'Not authorized to create assignment for this class.' });
+    }
+    const result = await query(
+      'INSERT INTO assignments (class_id, title, description, due_date) VALUES (?, ?, ?, ?)',
+      [classId, title, description, due_date]
+    );
+    res.status(201).json({ assignment_id: result.insertId });
+  } catch (err) {
+    console.error('Create assignment error:', err);
+    res.status(500).json({ message: 'Server error', error: err });
+  }
+});
+
+// Edit assignment details
+router.put('/:assignmentId', authenticateToken, async (req, res) => {
+  const { assignmentId } = req.params;
+  const { title, description, due_date } = req.body;
+  try {
+    const rows = await query(
+      `SELECT a.assignment_id, c.instructor_id
+         FROM assignments a
+         JOIN classes c ON a.class_id = c.class_id
+        WHERE a.assignment_id = ?`,
+      [assignmentId]
+    );
+    if (rows.length === 0 || rows[0].instructor_id !== req.user.user_id) {
+      return res.status(403).json({ message: 'Not authorized to edit this assignment.' });
+    }
+    const fields = [];
+    const params = [];
+    if (title) { fields.push('title = ?'); params.push(title); }
+    if (description) { fields.push('description = ?'); params.push(description); }
+    if (due_date) { fields.push('due_date = ?'); params.push(due_date); }
+    if (fields.length === 0) {
+      return res.status(400).json({ message: 'No update fields provided.' });
+    }
+    params.push(assignmentId);
+    await query(`UPDATE assignments SET ${fields.join(', ')} WHERE assignment_id = ?`, params);
+    res.json({ message: 'Assignment updated successfully.' });
+  } catch (err) {
+    console.error('Edit assignment error:', err);
+    res.status(500).json({ message: 'Server error', error: err });
+  }
+});
+
+// Submit assignment
+router.post('/:assignmentId/submit', authenticateToken, async (req, res) => {
+  const { assignmentId } = req.params;
+  const { fileName, fileData } = req.body;
+  if (!fileName || !fileData) {
+    return res.status(400).json({ message: 'File is required.' });
+  }
+  try {
+    const check = await query('SELECT assignment_id FROM assignments WHERE assignment_id = ?', [assignmentId]);
+    if (check.length === 0) {
+      return res.status(404).json({ message: 'Assignment not found.' });
+    }
+    const buffer = Buffer.from(fileData, 'base64');
+    const userDir = path.join(submissionDir, String(req.user.user_id));
+    if (!fs.existsSync(userDir)) {
+      fs.mkdirSync(userDir, { recursive: true });
+    }
+    const storedName = `${Date.now()}-${fileName}`;
+    const filePath = path.join(userDir, storedName);
+    fs.writeFileSync(filePath, buffer);
+    const fileUrl = `/uploads/submissions/${req.user.user_id}/${storedName}`;
+    const result = await query(
+      'INSERT INTO submissions (assignment_id, student_id, file_url) VALUES (?, ?, ?)',
+      [assignmentId, req.user.user_id, fileUrl]
+    );
+    res.status(201).json({ submission_id: result.insertId, file_url: fileUrl });
+  } catch (err) {
+    console.error('Submit assignment error:', err);
+    res.status(500).json({ message: 'Server error', error: err });
+  }
+});
+
+// View submitted assignments (instructor)
+router.get('/:assignmentId/submissions', authenticateToken, async (req, res) => {
+  const { assignmentId } = req.params;
+  try {
+    const rows = await query(
+      `SELECT c.instructor_id
+         FROM assignments a
+         JOIN classes c ON a.class_id = c.class_id
+        WHERE a.assignment_id = ?`,
+      [assignmentId]
+    );
+    if (rows.length === 0) {
+      return res.status(404).json({ message: 'Assignment not found.' });
+    }
+    if (rows[0].instructor_id !== req.user.user_id) {
+      return res.status(403).json({ message: 'Not authorized to view submissions.' });
+    }
+    const submissions = await query(
+      `SELECT s.submission_id, s.file_url, s.submitted_at, u.name, g.score, g.feedback
+         FROM submissions s
+         JOIN users u ON s.student_id = u.user_id
+         LEFT JOIN grades g ON s.submission_id = g.submission_id
+        WHERE s.assignment_id = ?`,
+      [assignmentId]
+    );
+    res.json(submissions);
+  } catch (err) {
+    console.error('Fetch submissions error:', err);
+    res.status(500).json({ message: 'Server error', error: err });
+  }
+});
+
+// Grade assignment submission
+router.post('/submissions/:submissionId/grade', authenticateToken, async (req, res) => {
+  const { submissionId } = req.params;
+  const { score, feedback } = req.body;
+  try {
+    const rows = await query(
+      `SELECT s.submission_id, c.instructor_id
+         FROM submissions s
+         JOIN assignments a ON s.assignment_id = a.assignment_id
+         JOIN classes c ON a.class_id = c.class_id
+        WHERE s.submission_id = ?`,
+      [submissionId]
+    );
+    if (rows.length === 0) {
+      return res.status(404).json({ message: 'Submission not found.' });
+    }
+    if (rows[0].instructor_id !== req.user.user_id) {
+      return res.status(403).json({ message: 'Not authorized to grade this submission.' });
+    }
+    const existing = await query('SELECT grade_id FROM grades WHERE submission_id = ?', [submissionId]);
+    if (existing.length > 0) {
+      await query(
+        'UPDATE grades SET score = ?, feedback = ?, graded_by = ?, graded_at = NOW() WHERE grade_id = ?',
+        [score, feedback, req.user.user_id, existing[0].grade_id]
+      );
+    } else {
+      await query(
+        'INSERT INTO grades (submission_id, score, feedback, graded_by) VALUES (?, ?, ?, ?)',
+        [submissionId, score, feedback, req.user.user_id]
+      );
+    }
+    res.json({ message: 'Grade saved.' });
+  } catch (err) {
+    console.error('Grade submission error:', err);
+    res.status(500).json({ message: 'Server error', error: err });
+  }
+});
+
+// View grades for a class (student)
+router.get('/class/:classId/grades', authenticateToken, async (req, res) => {
+  const { classId } = req.params;
+  try {
+    const grades = await query(
+      `SELECT a.assignment_id, a.title, g.score, g.feedback
+         FROM assignments a
+         LEFT JOIN submissions s ON a.assignment_id = s.assignment_id AND s.student_id = ?
+         LEFT JOIN grades g ON s.submission_id = g.submission_id
+        WHERE a.class_id = ?`,
+      [req.user.user_id, classId]
+    );
+    res.json(grades);
+  } catch (err) {
+    console.error('Fetch grades error:', err);
+    res.status(500).json({ message: 'Server error', error: err });
+  }
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -11,6 +11,7 @@ const authRoutes = require('./routes/auth');
 const profileRoutes = require('./routes/profile');
 const classRoutes = require('./routes/classes');
 const materialRoutes = require('./routes/materials');
+const assignmentRoutes = require('./routes/assignments');
 
 const app = express();
 app.use(cors());
@@ -33,6 +34,7 @@ app.use('/api/auth', authRoutes);
 app.use('/api/profile', profileRoutes);
 app.use('/api/classes', classRoutes);
 app.use('/api/materials', materialRoutes);
+app.use('/api/assignments', assignmentRoutes);
 
 // Start server
 const PORT = process.env.PORT || 5000;

--- a/elearning-frontend/assets/css/assignments.css
+++ b/elearning-frontend/assets/css/assignments.css
@@ -1,0 +1,95 @@
+.assignment-page {
+    padding: 30px;
+}
+
+.course-selector {
+    margin-bottom: 20px;
+    font-size: 16px;
+}
+
+.course-selector select {
+    padding: 8px;
+    font-size: 16px;
+}
+
+.create-assignment {
+    margin-top: 20px;
+    background: #ffffff;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    padding: 15px;
+}
+
+.create-assignment input,
+.create-assignment textarea {
+    width: 100%;
+    margin-bottom: 10px;
+    padding: 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 16px;
+    resize: vertical;
+}
+
+.assignment-list {
+    margin-top: 30px;
+    display: grid;
+    gap: 15px;
+}
+
+.assignment-card {
+    background: #f9fafb;
+    border: 1px solid #e5e7eb;
+    border-radius: 6px;
+    padding: 15px;
+    font-size: 0.95rem;
+}
+
+.assignment-card h4 {
+    margin: 0 0 8px;
+    font-size: 1.1rem;
+    color: #1f2937;
+}
+
+.assignment-card p {
+    margin: 4px 0;
+    color: #4b5563;
+}
+
+.assignment-card .due {
+    font-size: 0.9rem;
+    color: #6b7280;
+}
+
+.assignment-card button {
+    margin-top: 10px;
+}
+
+.submissions {
+    margin-top: 10px;
+    background: #ffffff;
+    border: 1px solid #d1d5db;
+    border-radius: 4px;
+    padding: 10px;
+}
+
+.submission-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 8px;
+}
+
+.submission-row a {
+    color: #2563eb;
+    text-decoration: none;
+    font-size: 0.9rem;
+}
+
+.submission-row input[type="number"] {
+    width: 60px;
+}
+
+.submission-row input[type="text"] {
+    flex: 1;
+}

--- a/elearning-frontend/assets/js/assignments.js
+++ b/elearning-frontend/assets/js/assignments.js
@@ -1,0 +1,243 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const token = localStorage.getItem('userToken');
+  if (!token) {
+    window.location.href = 'login.html';
+    return;
+  }
+
+  const classSelect = document.getElementById('classSelect');
+  const createSection = document.querySelector('.create-assignment');
+  const assignmentList = document.getElementById('assignmentList');
+  const submitModal = document.getElementById('submitModal');
+  const submitFile = document.getElementById('submitFile');
+  const submitFileBtn = document.getElementById('submitFileBtn');
+  const modalClose = submitModal.querySelector('.close');
+  const assnTitle = document.getElementById('assnTitle');
+  const assnDesc = document.getElementById('assnDesc');
+  const assnDue = document.getElementById('assnDue');
+  const createBtn = document.getElementById('createAssnBtn');
+  let currentAssignment = null;
+  let currentClass = null;
+  let isInstructor = false;
+
+  // load class list
+  fetch('/api/classes', { headers: { 'Authorization': `Bearer ${token}` }})
+    .then(r => r.json())
+    .then(data => {
+      data.forEach(cls => {
+        const opt = document.createElement('option');
+        opt.value = cls.class_id;
+        opt.textContent = cls.title;
+        classSelect.appendChild(opt);
+      });
+    });
+
+  classSelect.addEventListener('change', () => {
+    currentClass = classSelect.value;
+    loadAssignments();
+  });
+
+  async function loadAssignments() {
+    assignmentList.innerHTML = '';
+    if (!currentClass) return;
+    const res = await fetch(`/api/assignments/class/${currentClass}`, {
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      assignmentList.textContent = data.message || 'Failed to load assignments';
+      return;
+    }
+    isInstructor = data.is_instructor;
+    createSection.style.display = isInstructor ? 'block' : 'none';
+    data.assignments.forEach(a => renderAssignment(a));
+  }
+
+  function renderAssignment(a) {
+    const card = document.createElement('div');
+    card.className = 'assignment-card';
+    card.innerHTML = `
+      <h4>${a.title}</h4>
+      <p>${a.description || ''}</p>
+      <p class="due">Due: ${a.due_date || 'N/A'}</p>
+    `;
+
+    if (isInstructor) {
+      const editBtn = document.createElement('button');
+      editBtn.textContent = 'Edit';
+      editBtn.addEventListener('click', () => editAssignment(a));
+      const subsBtn = document.createElement('button');
+      subsBtn.textContent = 'Submissions';
+      subsBtn.addEventListener('click', () => toggleSubmissions(a.assignment_id, card));
+      card.appendChild(editBtn);
+      card.appendChild(subsBtn);
+    } else {
+      if (a.score !== null) {
+        const grade = document.createElement('p');
+        grade.className = 'grade';
+        grade.textContent = `Score: ${a.score}${a.feedback ? ' - ' + a.feedback : ''}`;
+        card.appendChild(grade);
+      }
+      const submitBtn = document.createElement('button');
+      submitBtn.textContent = a.submission_id ? 'Resubmit' : 'Submit';
+      submitBtn.addEventListener('click', () => {
+        currentAssignment = a.assignment_id;
+        submitModal.classList.add('active');
+      });
+      card.appendChild(submitBtn);
+    }
+    assignmentList.appendChild(card);
+  }
+
+  // create assignment
+  createBtn.addEventListener('click', async () => {
+    if (!currentClass) return;
+    const body = {
+      title: assnTitle.value,
+      description: assnDesc.value,
+      due_date: assnDue.value
+    };
+    const res = await fetch(`/api/assignments/class/${currentClass}`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(body)
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      alert(data.message || 'Failed to create assignment');
+      return;
+    }
+    assnTitle.value = '';
+    assnDesc.value = '';
+    assnDue.value = '';
+    loadAssignments();
+  });
+
+  // edit assignment
+  async function editAssignment(a) {
+    const title = prompt('Title', a.title);
+    if (title === null) return;
+    const description = prompt('Description', a.description || '');
+    if (description === null) return;
+    const due = prompt('Due Date (YYYY-MM-DD)', a.due_date || '');
+    const res = await fetch(`/api/assignments/${a.assignment_id}`, {
+      method: 'PUT',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ title, description, due_date: due })
+    });
+    const data = await res.json();
+    if (!res.ok) alert(data.message || 'Update failed');
+    loadAssignments();
+  }
+
+  // handle submissions view
+  async function toggleSubmissions(assignmentId, card) {
+    let existing = card.querySelector('.submissions');
+    if (existing) {
+      existing.remove();
+      return;
+    }
+    const container = document.createElement('div');
+    container.className = 'submissions';
+    container.textContent = 'Loading...';
+    card.appendChild(container);
+    const res = await fetch(`/api/assignments/${assignmentId}/submissions`, {
+      headers: { 'Authorization': `Bearer ${token}` }
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      container.textContent = data.message || 'Failed to load submissions';
+      return;
+    }
+    container.innerHTML = '';
+    if (data.length === 0) {
+      container.textContent = 'No submissions yet.';
+      return;
+    }
+    data.forEach(sub => {
+      const row = document.createElement('div');
+      row.className = 'submission-row';
+      const name = document.createElement('span');
+      name.textContent = sub.name;
+      const link = document.createElement('a');
+      link.href = sub.file_url;
+      link.textContent = 'Download';
+      link.target = '_blank';
+      const scoreInput = document.createElement('input');
+      scoreInput.type = 'number';
+      scoreInput.placeholder = 'Score';
+      if (sub.score !== null) scoreInput.value = sub.score;
+      const fbInput = document.createElement('input');
+      fbInput.type = 'text';
+      fbInput.placeholder = 'Feedback';
+      if (sub.feedback) fbInput.value = sub.feedback;
+      const saveBtn = document.createElement('button');
+      saveBtn.textContent = 'Save';
+      saveBtn.addEventListener('click', () => gradeSubmission(sub.submission_id, scoreInput.value, fbInput.value));
+      row.appendChild(name);
+      row.appendChild(link);
+      row.appendChild(scoreInput);
+      row.appendChild(fbInput);
+      row.appendChild(saveBtn);
+      container.appendChild(row);
+    });
+  }
+
+  async function gradeSubmission(id, score, feedback) {
+    const res = await fetch(`/api/assignments/submissions/${id}/grade`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ score, feedback })
+    });
+    const data = await res.json();
+    if (!res.ok) alert(data.message || 'Failed to save grade');
+  }
+
+  // submit assignment
+  submitFileBtn.addEventListener('click', () => {
+    const file = submitFile.files[0];
+    if (!file || !currentAssignment) return;
+    const reader = new FileReader();
+    reader.onload = async () => {
+      const base64 = reader.result.split(',')[1];
+      const res = await fetch(`/api/assignments/${currentAssignment}/submit`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ fileName: file.name, fileData: base64 })
+      });
+      const data = await res.json();
+      if (!res.ok) alert(data.message || 'Submission failed');
+      submitModal.classList.remove('active');
+      submitFile.value = '';
+      loadAssignments();
+    };
+    reader.readAsDataURL(file);
+  });
+
+  modalClose.addEventListener('click', () => {
+    submitModal.classList.remove('active');
+  });
+
+  // logout handling
+  const logout = document.getElementById('logout');
+  if (logout) {
+    logout.addEventListener('click', (e) => {
+      e.preventDefault();
+      localStorage.removeItem('userToken');
+      localStorage.removeItem('userInfo');
+      window.location.href = 'login.html';
+    });
+  }
+});

--- a/elearning-frontend/assets/js/navigation.js
+++ b/elearning-frontend/assets/js/navigation.js
@@ -4,6 +4,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const joinBtn = document.getElementById('openJoin');
   const createBtn = document.getElementById('openCreate');
   const materialsBtn = document.getElementById('openMaterials');
+  const assignmentsBtn = document.getElementById('openAssignments');
   const joinModal = document.getElementById('joinModal');
   const createModal = document.getElementById('createModal');
   const closeButtons = document.querySelectorAll('.close');
@@ -13,6 +14,9 @@ document.addEventListener('DOMContentLoaded', () => {
   createBtn.addEventListener('click', () => createModal.classList.add('active'));
   materialsBtn.addEventListener('click', () => {
     window.location.href = 'materials.html';
+  });
+  assignmentsBtn.addEventListener('click', () => {
+    window.location.href = 'assignments.html';
   });
 
   // Close modals

--- a/elearning-frontend/pages/assignments.html
+++ b/elearning-frontend/pages/assignments.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Assignments</title>
+    <link rel="stylesheet" href="../assets/css/dashboard.css">
+    <link rel="stylesheet" href="../assets/css/assignments.css">
+</head>
+<body>
+    <header class="header">
+        <div class="logo">eLearnHub</div>
+        <nav>
+            <a href="navigation.html">Navigation</a>
+            <a href="#" id="logout">Logout</a>
+        </nav>
+    </header>
+
+    <main class="assignment-page">
+        <h2>Assignment Management</h2>
+        <div class="course-selector">
+            <label for="classSelect">Select Class:</label>
+            <select id="classSelect">
+                <option value="">-- Choose a Class --</option>
+            </select>
+        </div>
+
+        <div class="create-assignment" style="display:none;">
+            <h3>Create Assignment</h3>
+            <input type="text" id="assnTitle" placeholder="Title">
+            <textarea id="assnDesc" placeholder="Description"></textarea>
+            <input type="date" id="assnDue">
+            <button id="createAssnBtn">Create</button>
+        </div>
+
+        <div id="assignmentList" class="assignment-list"></div>
+    </main>
+
+    <!-- Modal for submitting assignment -->
+    <div id="submitModal" class="modal">
+        <div class="modal-content">
+            <span class="close">&times;</span>
+            <h3>Submit Assignment</h3>
+            <input type="file" id="submitFile">
+            <button id="submitFileBtn">Submit</button>
+        </div>
+    </div>
+
+    <script src="../assets/js/assignments.js"></script>
+</body>
+</html>

--- a/elearning-frontend/pages/navigation.html
+++ b/elearning-frontend/pages/navigation.html
@@ -21,6 +21,7 @@
             <button class="nav-btn" id="openJoin">Join Class</button>
             <button class="nav-btn" id="openCreate">Create Class</button>
             <button class="nav-btn" id="openMaterials">Course Materials</button>
+            <button class="nav-btn" id="openAssignments">Assignments</button>
         </div>
     </main>
 


### PR DESCRIPTION
## Summary
- add dedicated assignment API for creating, editing, submitting, grading and listing grades
- introduce assignment management page with styling and submission modal
- extend navigation to access assignments and register new backend route

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6893ff24b29c8323a661b0d6a8b9cc30