### PR TITLE
feat: add announcements and discussions with notifications

### DIFF
--- a/backend/routes/announcements.js
+++ b/backend/routes/announcements.js
@@ -1,0 +1,86 @@
+const express = require('express');
+const router = express.Router();
+const db = require('../config/db');
+const jwt = require('jsonwebtoken');
+require('dotenv').config();
+
+function query(sql, params) {
+  return new Promise((resolve, reject) => {
+    db.query(sql, params, (err, results) => {
+      if (err) reject(err);
+      else resolve(results);
+    });
+  });
+}
+
+function authenticateToken(req, res, next) {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
+  if (!token) return res.status(401).json({ message: 'No token provided.' });
+  jwt.verify(token, process.env.JWT_SECRET, (err, user) => {
+    if (err) return res.status(403).json({ message: 'Invalid token.' });
+    req.user = user;
+    next();
+  });
+}
+
+// Get announcements for a class
+router.get('/class/:classId', authenticateToken, async (req, res) => {
+  const { classId } = req.params;
+  try {
+    const rows = await query(
+      `SELECT announcement_id, message, posted_by, posted_at
+         FROM announcements
+        WHERE class_id = ?
+        ORDER BY posted_at DESC`,
+      [classId]
+    );
+    res.json(rows);
+  } catch (err) {
+    console.error('Fetch announcements error:', err);
+    res.status(500).json({ message: 'Server error', error: err });
+  }
+});
+
+// Post announcement (instructor only)
+router.post('/class/:classId', authenticateToken, async (req, res) => {
+  const { classId } = req.params;
+  const { message } = req.body;
+  if (!message) {
+    return res.status(400).json({ message: 'Message is required.' });
+  }
+  try {
+    const rows = await query('SELECT instructor_id FROM classes WHERE class_id = ?', [classId]);
+    if (rows.length === 0) {
+      return res.status(404).json({ message: 'Class not found.' });
+    }
+    if (rows[0].instructor_id !== req.user.user_id) {
+      return res.status(403).json({ message: 'Not authorized to post announcement for this class.' });
+    }
+    const result = await query('INSERT INTO announcements (class_id, message, posted_by) VALUES (?, ?, ?)', [classId, message, req.user.user_id]);
+
+    // Notify enrolled students
+    const students = await query("SELECT student_id FROM enrollments WHERE class_id = ? AND status = 'approved'", [classId]);
+    if (students.length > 0) {
+      const values = [];
+      const placeholders = students
+        .filter(s => s.student_id !== req.user.user_id)
+        .map(() => '(?, ?)');
+      students
+        .filter(s => s.student_id !== req.user.user_id)
+        .forEach(s => {
+          values.push(s.student_id, `New announcement in class ${classId}`);
+        });
+      if (values.length > 0) {
+        await query(`INSERT INTO notifications (user_id, message) VALUES ${placeholders.join(', ')}`, values);
+      }
+    }
+
+    res.status(201).json({ announcement_id: result.insertId });
+  } catch (err) {
+    console.error('Post announcement error:', err);
+    res.status(500).json({ message: 'Server error', error: err });
+  }
+});
+
+module.exports = router;

--- a/backend/routes/notifications.js
+++ b/backend/routes/notifications.js
@@ -1,0 +1,56 @@
+const express = require('express');
+const router = express.Router();
+const db = require('../config/db');
+const jwt = require('jsonwebtoken');
+require('dotenv').config();
+
+function query(sql, params) {
+  return new Promise((resolve, reject) => {
+    db.query(sql, params, (err, results) => {
+      if (err) reject(err);
+      else resolve(results);
+    });
+  });
+}
+
+function authenticateToken(req, res, next) {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
+  if (!token) return res.status(401).json({ message: 'No token provided.' });
+  jwt.verify(token, process.env.JWT_SECRET, (err, user) => {
+    if (err) return res.status(403).json({ message: 'Invalid token.' });
+    req.user = user;
+    next();
+  });
+}
+
+// Get notifications for the user
+router.get('/', authenticateToken, async (req, res) => {
+  try {
+    const notes = await query(
+      `SELECT notification_id, message, is_read, created_at
+         FROM notifications
+        WHERE user_id = ?
+        ORDER BY created_at DESC`,
+      [req.user.user_id]
+    );
+    res.json(notes);
+  } catch (err) {
+    console.error('Fetch notifications error:', err);
+    res.status(500).json({ message: 'Server error', error: err });
+  }
+});
+
+// Mark notification as read
+router.post('/:id/read', authenticateToken, async (req, res) => {
+  const { id } = req.params;
+  try {
+    await query('UPDATE notifications SET is_read = 1 WHERE notification_id = ? AND user_id = ?', [id, req.user.user_id]);
+    res.json({ message: 'Notification marked as read.' });
+  } catch (err) {
+    console.error('Mark notification read error:', err);
+    res.status(500).json({ message: 'Server error', error: err });
+  }
+});
+
+module.exports = router;

--- a/backend/routes/threads.js
+++ b/backend/routes/threads.js
@@ -1,0 +1,131 @@
+const express = require('express');
+const router = express.Router();
+const db = require('../config/db');
+const jwt = require('jsonwebtoken');
+require('dotenv').config();
+
+function query(sql, params) {
+  return new Promise((resolve, reject) => {
+    db.query(sql, params, (err, results) => {
+      if (err) reject(err);
+      else resolve(results);
+    });
+  });
+}
+
+function authenticateToken(req, res, next) {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
+  if (!token) return res.status(401).json({ message: 'No token provided.' });
+  jwt.verify(token, process.env.JWT_SECRET, (err, user) => {
+    if (err) return res.status(403).json({ message: 'Invalid token.' });
+    req.user = user;
+    next();
+  });
+}
+
+async function isClassMember(classId, userId) {
+  const rows = await query('SELECT instructor_id FROM classes WHERE class_id = ?', [classId]);
+  if (rows.length === 0) return false;
+  if (rows[0].instructor_id === userId) return true;
+  const enrolled = await query("SELECT enrollment_id FROM enrollments WHERE class_id = ? AND student_id = ? AND status = 'approved'", [classId, userId]);
+  return enrolled.length > 0;
+}
+
+// Fetch threads for a class
+router.get('/class/:classId', authenticateToken, async (req, res) => {
+  const { classId } = req.params;
+  try {
+    const threads = await query(
+      `SELECT t.thread_id, t.title, t.content, t.created_by, t.created_at, u.name
+         FROM threads t
+         JOIN users u ON t.created_by = u.user_id
+        WHERE t.class_id = ?
+        ORDER BY t.created_at DESC`,
+      [classId]
+    );
+    res.json(threads);
+  } catch (err) {
+    console.error('Fetch threads error:', err);
+    res.status(500).json({ message: 'Server error', error: err });
+  }
+});
+
+// Start a thread
+router.post('/class/:classId', authenticateToken, async (req, res) => {
+  const { classId } = req.params;
+  const { title, content } = req.body;
+  if (!title || !content) {
+    return res.status(400).json({ message: 'Title and content are required.' });
+  }
+  try {
+    const member = await isClassMember(classId, req.user.user_id);
+    if (!member) {
+      return res.status(403).json({ message: 'Not authorized to create thread in this class.' });
+    }
+    const result = await query('INSERT INTO threads (class_id, created_by, title, content) VALUES (?, ?, ?, ?)', [classId, req.user.user_id, title, content]);
+
+    // Notify instructor if student started thread
+    const cls = await query('SELECT instructor_id FROM classes WHERE class_id = ?', [classId]);
+    if (cls.length > 0 && cls[0].instructor_id !== req.user.user_id) {
+      await query('INSERT INTO notifications (user_id, message) VALUES (?, ?)', [cls[0].instructor_id, `New discussion thread in class ${classId}`]);
+    }
+
+    res.status(201).json({ thread_id: result.insertId });
+  } catch (err) {
+    console.error('Create thread error:', err);
+    res.status(500).json({ message: 'Server error', error: err });
+  }
+});
+
+// Get comments for a thread
+router.get('/:threadId/comments', authenticateToken, async (req, res) => {
+  const { threadId } = req.params;
+  try {
+    const comments = await query(
+      `SELECT c.comment_id, c.content, c.posted_by, c.posted_at, u.name
+         FROM comments c
+         JOIN users u ON c.posted_by = u.user_id
+        WHERE c.thread_id = ?
+        ORDER BY c.posted_at ASC`,
+      [threadId]
+    );
+    res.json(comments);
+  } catch (err) {
+    console.error('Fetch comments error:', err);
+    res.status(500).json({ message: 'Server error', error: err });
+  }
+});
+
+// Post comment on thread
+router.post('/:threadId/comments', authenticateToken, async (req, res) => {
+  const { threadId } = req.params;
+  const { content } = req.body;
+  if (!content) {
+    return res.status(400).json({ message: 'Content is required.' });
+  }
+  try {
+    const threads = await query('SELECT class_id, created_by FROM threads WHERE thread_id = ?', [threadId]);
+    if (threads.length === 0) {
+      return res.status(404).json({ message: 'Thread not found.' });
+    }
+    const classId = threads[0].class_id;
+    const member = await isClassMember(classId, req.user.user_id);
+    if (!member) {
+      return res.status(403).json({ message: 'Not authorized to comment on this thread.' });
+    }
+    const result = await query('INSERT INTO comments (thread_id, posted_by, content) VALUES (?, ?, ?)', [threadId, req.user.user_id, content]);
+
+    // Notify thread creator
+    if (threads[0].created_by !== req.user.user_id) {
+      await query('INSERT INTO notifications (user_id, message) VALUES (?, ?)', [threads[0].created_by, 'New comment on your thread']);
+    }
+
+    res.status(201).json({ comment_id: result.insertId });
+  } catch (err) {
+    console.error('Post comment error:', err);
+    res.status(500).json({ message: 'Server error', error: err });
+  }
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -12,6 +12,9 @@ const profileRoutes = require('./routes/profile');
 const classRoutes = require('./routes/classes');
 const materialRoutes = require('./routes/materials');
 const assignmentRoutes = require('./routes/assignments');
+const announcementRoutes = require('./routes/announcements');
+const threadRoutes = require('./routes/threads');
+const notificationRoutes = require('./routes/notifications');
 
 const app = express();
 app.use(cors());
@@ -35,6 +38,9 @@ app.use('/api/profile', profileRoutes);
 app.use('/api/classes', classRoutes);
 app.use('/api/materials', materialRoutes);
 app.use('/api/assignments', assignmentRoutes);
+app.use('/api/announcements', announcementRoutes);
+app.use('/api/threads', threadRoutes);
+app.use('/api/notifications', notificationRoutes);
 
 // Start server
 const PORT = process.env.PORT || 5000;

--- a/elearning-frontend/assets/css/communication.css
+++ b/elearning-frontend/assets/css/communication.css
@@ -1,0 +1,74 @@
+.communication-header {
+  background: #0d6efd;
+  color: #fff;
+  text-align: center;
+  padding: 20px;
+}
+
+.course-selector {
+  margin: 20px 0;
+}
+
+.announce-section {
+  background: #fff3cd;
+  padding: 20px;
+  border-radius: 8px;
+  margin-bottom: 20px;
+}
+.announce-section h3 {
+  color: #856404;
+  font-size: 1.5rem;
+}
+
+.thread-section {
+  background: #e2e3e5;
+  padding: 20px;
+  border-radius: 8px;
+  margin-bottom: 20px;
+}
+.thread-section h3 {
+  color: #383d41;
+  font-size: 1.5rem;
+}
+
+.notification-section {
+  background: #d1e7dd;
+  padding: 20px;
+  border-radius: 8px;
+}
+.notification-section h3 {
+  color: #0f5132;
+  font-size: 1.5rem;
+}
+
+form textarea,
+form input {
+  width: 100%;
+  padding: 8px;
+  margin-bottom: 10px;
+  font-size: 1rem;
+}
+form button {
+  padding: 8px 16px;
+}
+
+.announcement {
+  border-bottom: 1px solid #ffeeba;
+  padding: 8px 0;
+}
+
+.thread {
+  border-bottom: 1px solid #ced4da;
+  padding: 8px 0;
+}
+
+.comment {
+  margin-left: 15px;
+  font-size: 0.9rem;
+  color: #495057;
+}
+
+.notification {
+  border-bottom: 1px solid #badbcc;
+  padding: 6px 0;
+}

--- a/elearning-frontend/assets/js/communication.js
+++ b/elearning-frontend/assets/js/communication.js
@@ -1,0 +1,209 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const token = localStorage.getItem('userToken');
+  if (!token) {
+    window.location.href = 'login.html';
+    return;
+  }
+
+  const courseSelect = document.getElementById('courseSelect');
+  const announceSection = document.querySelector('.announce-section');
+  const threadSection = document.querySelector('.thread-section');
+  const notifSection = document.querySelector('.notification-section');
+  const announcementsList = document.getElementById('announcementsList');
+  const threadsList = document.getElementById('threadsList');
+  const notificationList = document.getElementById('notificationList');
+  let currentClassId = '';
+
+  async function loadCourses() {
+    try {
+      const res = await fetch('/api/classes', {
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+      const data = await res.json();
+      data.forEach(cls => {
+        const opt = document.createElement('option');
+        opt.value = cls.class_id;
+        opt.textContent = cls.title;
+        courseSelect.appendChild(opt);
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  courseSelect.addEventListener('change', () => {
+    currentClassId = courseSelect.value;
+    if (!currentClassId) {
+      announceSection.style.display = 'none';
+      threadSection.style.display = 'none';
+      return;
+    }
+    announceSection.style.display = 'block';
+    threadSection.style.display = 'block';
+    loadAnnouncements();
+    loadThreads();
+  });
+
+  async function loadAnnouncements() {
+    announcementsList.innerHTML = '';
+    try {
+      const res = await fetch(`/api/announcements/class/${currentClassId}`, {
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+      const data = await res.json();
+      data.forEach(a => {
+        const div = document.createElement('div');
+        div.className = 'announcement';
+        div.textContent = a.message;
+        announcementsList.appendChild(div);
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  document.getElementById('announceForm').addEventListener('submit', async e => {
+    e.preventDefault();
+    const message = document.getElementById('announceMessage').value.trim();
+    if (!message) return;
+    try {
+      const res = await fetch(`/api/announcements/class/${currentClassId}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`
+        },
+        body: JSON.stringify({ message })
+      });
+      if (res.ok) {
+        document.getElementById('announceMessage').value = '';
+        loadAnnouncements();
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  });
+
+  async function loadThreads() {
+    threadsList.innerHTML = '';
+    try {
+      const res = await fetch(`/api/threads/class/${currentClassId}`, {
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+      const data = await res.json();
+      data.forEach(t => createThreadElement(t));
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  function createThreadElement(thread) {
+    const div = document.createElement('div');
+    div.className = 'thread';
+    div.innerHTML = `<strong>${thread.title}</strong><p>${thread.content}</p>`;
+    const commentsContainer = document.createElement('div');
+    div.appendChild(commentsContainer);
+    loadComments(thread.thread_id, commentsContainer);
+
+    const form = document.createElement('form');
+    form.innerHTML = `<input type="text" class="comment-input" placeholder="Add comment"><button type="submit">Post</button>`;
+    form.addEventListener('submit', async e => {
+      e.preventDefault();
+      const input = form.querySelector('input');
+      const content = input.value.trim();
+      if (!content) return;
+      try {
+        const res = await fetch(`/api/threads/${thread.thread_id}/comments`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${token}`
+          },
+          body: JSON.stringify({ content })
+        });
+        if (res.ok) {
+          input.value = '';
+          loadComments(thread.thread_id, commentsContainer);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    });
+    div.appendChild(form);
+    threadsList.appendChild(div);
+  }
+
+  async function loadComments(threadId, container) {
+    container.innerHTML = '';
+    try {
+      const res = await fetch(`/api/threads/${threadId}/comments`, {
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+      const data = await res.json();
+      data.forEach(c => {
+        const p = document.createElement('div');
+        p.className = 'comment';
+        p.textContent = `${c.name}: ${c.content}`;
+        container.appendChild(p);
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  document.getElementById('threadForm').addEventListener('submit', async e => {
+    e.preventDefault();
+    const title = document.getElementById('threadTitle').value.trim();
+    const content = document.getElementById('threadContent').value.trim();
+    if (!title || !content) return;
+    try {
+      const res = await fetch(`/api/threads/class/${currentClassId}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`
+        },
+        body: JSON.stringify({ title, content })
+      });
+      if (res.ok) {
+        document.getElementById('threadTitle').value = '';
+        document.getElementById('threadContent').value = '';
+        loadThreads();
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  });
+
+  async function loadNotifications() {
+    notificationList.innerHTML = '';
+    try {
+      const res = await fetch('/api/notifications', {
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+      const data = await res.json();
+      data.forEach(n => {
+        const div = document.createElement('div');
+        div.className = 'notification';
+        div.textContent = n.message;
+        notificationList.appendChild(div);
+      });
+      notifSection.style.display = 'block';
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  loadCourses();
+  loadNotifications();
+
+  const logout = document.getElementById('logout');
+  if (logout) {
+    logout.addEventListener('click', e => {
+      e.preventDefault();
+      localStorage.removeItem('userToken');
+      localStorage.removeItem('userInfo');
+      window.location.href = 'login.html';
+    });
+  }
+});

--- a/elearning-frontend/assets/js/navigation.js
+++ b/elearning-frontend/assets/js/navigation.js
@@ -5,6 +5,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const createBtn = document.getElementById('openCreate');
   const materialsBtn = document.getElementById('openMaterials');
   const assignmentsBtn = document.getElementById('openAssignments');
+  const communicationBtn = document.getElementById('openCommunication');
   const joinModal = document.getElementById('joinModal');
   const createModal = document.getElementById('createModal');
   const closeButtons = document.querySelectorAll('.close');
@@ -17,6 +18,9 @@ document.addEventListener('DOMContentLoaded', () => {
   });
   assignmentsBtn.addEventListener('click', () => {
     window.location.href = 'assignments.html';
+  });
+  communicationBtn.addEventListener('click', () => {
+    window.location.href = 'communication.html';
   });
 
   // Close modals

--- a/elearning-frontend/pages/communication.html
+++ b/elearning-frontend/pages/communication.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Communication & Notifications</title>
+    <link rel="stylesheet" href="../assets/css/dashboard.css">
+    <link rel="stylesheet" href="../assets/css/communication.css">
+</head>
+<body>
+    <header class="header">
+        <div class="logo">eLearnHub</div>
+        <nav>
+            <a href="navigation.html">Navigation</a>
+            <a href="#" id="logout">Logout</a>
+        </nav>
+    </header>
+
+    <section class="communication-header">
+        <h2>Communication & Notifications</h2>
+    </section>
+
+    <main>
+        <div class="course-selector">
+            <label for="courseSelect">Select Course:</label>
+            <select id="courseSelect">
+                <option value="">-- Choose a Course --</option>
+            </select>
+        </div>
+
+        <div class="announce-section" style="display:none;">
+            <h3>Announcements</h3>
+            <form id="announceForm">
+                <textarea id="announceMessage" placeholder="Write announcement"></textarea>
+                <button type="submit">Post Announcement</button>
+            </form>
+            <div id="announcementsList"></div>
+        </div>
+
+        <div class="thread-section" style="display:none;">
+            <h3>Discussion Threads</h3>
+            <form id="threadForm">
+                <input type="text" id="threadTitle" placeholder="Thread title">
+                <textarea id="threadContent" placeholder="Start a discussion"></textarea>
+                <button type="submit">Start Thread</button>
+            </form>
+            <div id="threadsList"></div>
+        </div>
+
+        <div class="notification-section" style="display:none;">
+            <h3>Notifications</h3>
+            <div id="notificationList"></div>
+        </div>
+    </main>
+
+    <script src="../assets/js/communication.js"></script>
+</body>
+</html>

--- a/elearning-frontend/pages/navigation.html
+++ b/elearning-frontend/pages/navigation.html
@@ -22,6 +22,7 @@
             <button class="nav-btn" id="openCreate">Create Class</button>
             <button class="nav-btn" id="openMaterials">Course Materials</button>
             <button class="nav-btn" id="openAssignments">Assignments</button>
+            <button class="nav-btn" id="openCommunication">Communication</button>
         </div>
     </main>
 


### PR DESCRIPTION
## Summary
- add backend APIs for announcements, discussions, and notifications
- build communication page with colorful sections and adjustable fonts
- link communication tools into site navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `node -e "require('./backend/routes/announcements.js');"` *(fails: connect ECONNREFUSED)*
- `node -e "require('./backend/routes/threads.js');"` *(fails: connect ECONNREFUSED)*
- `node -e "require('./backend/routes/notifications.js');"` *(fails: connect ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_6894067883788323b729b0eed6e72e2e