### PR TITLE
feat: add live lecture interactions and analytics

### DIFF
--- a/backend/models/lectureStore.js
+++ b/backend/models/lectureStore.js
@@ -1,0 +1,2 @@
+const lectures = [];
+module.exports = { lectures };

--- a/backend/routes/analytics.js
+++ b/backend/routes/analytics.js
@@ -1,0 +1,27 @@
+const express = require('express');
+const router = express.Router();
+const jwt = require('jsonwebtoken');
+require('dotenv').config();
+
+const { lectures } = require('../models/lectureStore');
+
+function authenticateToken(req, res, next) {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
+  if (!token) return res.status(401).json({ message: 'No token provided.' });
+  jwt.verify(token, process.env.JWT_SECRET, (err, user) => {
+    if (err) return res.status(403).json({ message: 'Invalid token.' });
+    req.user = user;
+    next();
+  });
+}
+
+// Basic analytics for lectures
+router.get('/lectures', authenticateToken, (req, res) => {
+  const scheduled = lectures.length;
+  const participants = lectures.reduce((sum, l) => sum + l.participants.length, 0);
+  const screenShares = lectures.filter(l => l.screenShared).length;
+  res.json({ scheduled, participants, screenShares });
+});
+
+module.exports = router;

--- a/backend/routes/lectures.js
+++ b/backend/routes/lectures.js
@@ -1,0 +1,54 @@
+const express = require('express');
+const router = express.Router();
+const jwt = require('jsonwebtoken');
+require('dotenv').config();
+
+const { lectures } = require('../models/lectureStore');
+
+function authenticateToken(req, res, next) {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
+  if (!token) return res.status(401).json({ message: 'No token provided.' });
+  jwt.verify(token, process.env.JWT_SECRET, (err, user) => {
+    if (err) return res.status(403).json({ message: 'Invalid token.' });
+    req.user = user;
+    next();
+  });
+}
+
+// Schedule a lecture
+router.post('/schedule', authenticateToken, (req, res) => {
+  const { title, time } = req.body;
+  if (!title || !time) {
+    return res.status(400).json({ message: 'Title and time are required.' });
+  }
+  const lecture = {
+    id: lectures.length + 1,
+    title,
+    time,
+    participants: [],
+    screenShared: false
+  };
+  lectures.push(lecture);
+  res.status(201).json(lecture);
+});
+
+// Join a lecture
+router.post('/:id/join', authenticateToken, (req, res) => {
+  const lecture = lectures.find(l => l.id === parseInt(req.params.id));
+  if (!lecture) return res.status(404).json({ message: 'Lecture not found.' });
+  if (!lecture.participants.includes(req.user.user_id)) {
+    lecture.participants.push(req.user.user_id);
+  }
+  res.json({ message: 'Joined lecture.' });
+});
+
+// Share screen during a lecture
+router.post('/:id/share-screen', authenticateToken, (req, res) => {
+  const lecture = lectures.find(l => l.id === parseInt(req.params.id));
+  if (!lecture) return res.status(404).json({ message: 'Lecture not found.' });
+  lecture.screenShared = true;
+  res.json({ message: 'Screen sharing started.' });
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -15,6 +15,8 @@ const assignmentRoutes = require('./routes/assignments');
 const announcementRoutes = require('./routes/announcements');
 const threadRoutes = require('./routes/threads');
 const notificationRoutes = require('./routes/notifications');
+const lectureRoutes = require('./routes/lectures');
+const analyticsRoutes = require('./routes/analytics');
 
 const app = express();
 app.use(cors());
@@ -41,6 +43,8 @@ app.use('/api/assignments', assignmentRoutes);
 app.use('/api/announcements', announcementRoutes);
 app.use('/api/threads', threadRoutes);
 app.use('/api/notifications', notificationRoutes);
+app.use('/api/lectures', lectureRoutes);
+app.use('/api/analytics', analyticsRoutes);
 
 // Start server
 const PORT = process.env.PORT || 5000;

--- a/elearning-frontend/assets/js/live.js
+++ b/elearning-frontend/assets/js/live.js
@@ -1,0 +1,80 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const scheduleForm = document.getElementById('scheduleForm');
+  const joinForm = document.getElementById('joinForm');
+  const shareForm = document.getElementById('shareForm');
+  const refreshBtn = document.getElementById('refreshAnalytics');
+  const analyticsOutput = document.getElementById('analyticsOutput');
+  const token = localStorage.getItem('userToken');
+
+  scheduleForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const title = document.getElementById('lectureTitle').value.trim();
+    const time = document.getElementById('lectureTime').value;
+    try {
+      const res = await fetch('http://localhost:5000/api/lectures/schedule', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`
+        },
+        body: JSON.stringify({ title, time })
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.message || 'Failed to schedule');
+      alert(`Lecture scheduled with ID ${data.id}`);
+    } catch (err) {
+      alert(err.message);
+    }
+  });
+
+  joinForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const id = document.getElementById('lectureId').value;
+    try {
+      const res = await fetch(`http://localhost:5000/api/lectures/${id}/join`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token}`
+        }
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.message || 'Failed to join');
+      alert('Joined lecture.');
+    } catch (err) {
+      alert(err.message);
+    }
+  });
+
+  shareForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const id = document.getElementById('shareLectureId').value;
+    try {
+      const res = await fetch(`http://localhost:5000/api/lectures/${id}/share-screen`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token}`
+        }
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.message || 'Failed to share screen');
+      alert('Screen sharing started.');
+    } catch (err) {
+      alert(err.message);
+    }
+  });
+
+  refreshBtn.addEventListener('click', async () => {
+    try {
+      const res = await fetch('http://localhost:5000/api/analytics/lectures', {
+        headers: {
+          'Authorization': `Bearer ${token}`
+        }
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.message || 'Failed to fetch analytics');
+      analyticsOutput.textContent = JSON.stringify(data, null, 2);
+    } catch (err) {
+      alert(err.message);
+    }
+  });
+});

--- a/elearning-frontend/assets/js/navigation.js
+++ b/elearning-frontend/assets/js/navigation.js
@@ -6,6 +6,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const materialsBtn = document.getElementById('openMaterials');
   const assignmentsBtn = document.getElementById('openAssignments');
   const communicationBtn = document.getElementById('openCommunication');
+  const liveBtn = document.getElementById('openLive');
   const joinModal = document.getElementById('joinModal');
   const createModal = document.getElementById('createModal');
   const closeButtons = document.querySelectorAll('.close');
@@ -21,6 +22,9 @@ document.addEventListener('DOMContentLoaded', () => {
   });
   communicationBtn.addEventListener('click', () => {
     window.location.href = 'communication.html';
+  });
+  liveBtn.addEventListener('click', () => {
+    window.location.href = 'live.html';
   });
 
   // Close modals

--- a/elearning-frontend/pages/live.html
+++ b/elearning-frontend/pages/live.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Live Lectures</title>
+    <link rel="stylesheet" href="../assets/css/dashboard.css">
+</head>
+<body>
+    <header class="header">
+        <div class="logo">eLearnHub</div>
+        <nav>
+            <a href="navigation.html">Navigation</a>
+            <a href="#" id="logout">Logout</a>
+        </nav>
+    </header>
+    <main>
+        <h2>Live Lectures</h2>
+        <section>
+            <h3>Schedule Lecture</h3>
+            <form id="scheduleForm">
+                <input type="text" id="lectureTitle" placeholder="Title" required>
+                <input type="datetime-local" id="lectureTime" required>
+                <button type="submit">Schedule</button>
+            </form>
+        </section>
+        <section>
+            <h3>Join Lecture</h3>
+            <form id="joinForm">
+                <input type="number" id="lectureId" placeholder="Lecture ID" required>
+                <button type="submit">Join</button>
+            </form>
+        </section>
+        <section>
+            <h3>Share Screen</h3>
+            <form id="shareForm">
+                <input type="number" id="shareLectureId" placeholder="Lecture ID" required>
+                <button type="submit">Share Screen</button>
+            </form>
+        </section>
+        <section>
+            <h3>Analytics</h3>
+            <button id="refreshAnalytics">Refresh</button>
+            <pre id="analyticsOutput"></pre>
+        </section>
+    </main>
+    <script src="../assets/js/live.js"></script>
+</body>
+</html>

--- a/elearning-frontend/pages/navigation.html
+++ b/elearning-frontend/pages/navigation.html
@@ -23,6 +23,7 @@
             <button class="nav-btn" id="openMaterials">Course Materials</button>
             <button class="nav-btn" id="openAssignments">Assignments</button>
             <button class="nav-btn" id="openCommunication">Communication</button>
+            <button class="nav-btn" id="openLive">Live Lectures</button>
         </div>
     </main>
 


### PR DESCRIPTION
## Summary
- add lecture API to schedule sessions, join classes, and start screen sharing
- expose analytics API to report lecture counts and participation
- create frontend pages and navigation for live lectures

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68940bf4ef34832397cf132e06231b6e