### PR TITLE
Remove static Loading text from dashboard

### DIFF
--- a/elearning-frontend/assets/js/assignments.js
+++ b/elearning-frontend/assets/js/assignments.js
@@ -197,7 +197,6 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     const container = document.createElement('div');
     container.className = 'submissions';
-    container.textContent = 'Loading...';
     card.appendChild(container);
     const res = await fetch(`/api/assignments/${assignmentId}/submissions`, {
       headers: { 'Authorization': `Bearer ${token}` }

--- a/elearning-frontend/assets/js/main.js
+++ b/elearning-frontend/assets/js/main.js
@@ -83,7 +83,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   async function loadAnnouncements(classes) {
     if (!annContainer) return;
-    annContainer.textContent = 'Loading...';
+    annContainer.textContent = '';
     const items = [];
     for (const cls of classes) {
       try {
@@ -116,7 +116,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   async function loadUpcomingTasks(classes) {
     if (!tasksContainer) return;
-    tasksContainer.textContent = 'Loading...';
+    tasksContainer.textContent = '';
     const items = [];
     const now = new Date();
     for (const cls of classes) {
@@ -219,7 +219,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const reqContainer = document.createElement('div');
     reqContainer.className = 'request-container';
-    reqContainer.textContent = 'Loading...';
     card.appendChild(reqContainer);
 
     try {


### PR DESCRIPTION
## Summary
- Clear announcement and task sections before fetching to avoid showing a static `Loading...` message
- Create request and submission containers without placeholder text so only dynamic data appears

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68940e19ddfc8323875d37fd97bddc08