### PR TITLE
Redesign live lectures page with responsive cards and styling

### DIFF
--- a/elearning-frontend/assets/css/live.css
+++ b/elearning-frontend/assets/css/live.css
@@ -1,0 +1,31 @@
+/* Styles specific to the live lectures page */
+
+.live-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 30px;
+    margin-top: 30px;
+}
+
+.live-grid .live-form {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.live-grid input {
+    padding: 10px;
+    border: 1px solid #ccc;
+    border-radius: 5px;
+    font-size: 16px;
+}
+
+.analytics-output {
+    background: #f9fafb;
+    padding: 15px;
+    border-radius: 5px;
+    border: 1px solid #e5e7eb;
+    max-height: 200px;
+    overflow-y: auto;
+}
+

--- a/elearning-frontend/pages/live.html
+++ b/elearning-frontend/pages/live.html
@@ -4,7 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Live Lectures</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer"/>
     <link rel="stylesheet" href="../assets/css/dashboard.css">
+    <link rel="stylesheet" href="../assets/css/live.css">
 </head>
 <body>
     <header class="header">
@@ -16,33 +21,35 @@
     </header>
     <main>
         <h2>Live Lectures</h2>
-        <section>
-            <h3>Schedule Lecture</h3>
-            <form id="scheduleForm">
-                <input type="text" id="lectureTitle" placeholder="Title" required>
-                <input type="datetime-local" id="lectureTime" required>
-                <button type="submit">Schedule</button>
-            </form>
-        </section>
-        <section>
-            <h3>Join Lecture</h3>
-            <form id="joinForm">
-                <input type="number" id="lectureId" placeholder="Lecture ID" required>
-                <button type="submit">Join</button>
-            </form>
-        </section>
-        <section>
-            <h3>Share Screen</h3>
-            <form id="shareForm">
-                <input type="number" id="shareLectureId" placeholder="Lecture ID" required>
-                <button type="submit">Share Screen</button>
-            </form>
-        </section>
-        <section>
-            <h3>Analytics</h3>
-            <button id="refreshAnalytics">Refresh</button>
-            <pre id="analyticsOutput"></pre>
-        </section>
+        <div class="live-grid">
+            <div class="card">
+                <h3><i class="fas fa-calendar-plus"></i> Schedule Lecture</h3>
+                <form id="scheduleForm" class="live-form">
+                    <input type="text" id="lectureTitle" placeholder="Title" required>
+                    <input type="datetime-local" id="lectureTime" required>
+                    <button type="submit">Schedule</button>
+                </form>
+            </div>
+            <div class="card">
+                <h3><i class="fas fa-door-open"></i> Join Lecture</h3>
+                <form id="joinForm" class="live-form">
+                    <input type="number" id="lectureId" placeholder="Lecture ID" required>
+                    <button type="submit">Join</button>
+                </form>
+            </div>
+            <div class="card">
+                <h3><i class="fas fa-share-square"></i> Share Screen</h3>
+                <form id="shareForm" class="live-form">
+                    <input type="number" id="shareLectureId" placeholder="Lecture ID" required>
+                    <button type="submit">Share Screen</button>
+                </form>
+            </div>
+            <div class="card">
+                <h3><i class="fas fa-chart-bar"></i> Analytics</h3>
+                <button id="refreshAnalytics">Refresh</button>
+                <pre id="analyticsOutput" class="analytics-output"></pre>
+            </div>
+        </div>
     </main>
     <script src="../assets/js/live.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- Revamp live lecture page with Font Awesome, Google Fonts, and responsive card layout
- Add dedicated `live.css` stylesheet for structured forms and analytics display

## Testing
- `npm test` *(fails: Missing script "test" in backend)*

------
https://chatgpt.com/codex/tasks/task_e_689419d4a2e883238367f7675cee93dd