### PR TITLE
Remove header from signup page

### DIFF
--- a/elearning-frontend/assets/css/signup.css
+++ b/elearning-frontend/assets/css/signup.css
@@ -12,41 +12,7 @@ body {
   min-height: 100vh;
 }
 
-/* HEADER */
-.site-header {
-  display: flex;
-  justify-content: space-between; /* keeps title left, nav right */
-  align-items: center;
-  background: #362f2f;
-  padding: 0.75rem 1.5rem;
-  box-shadow: 0 2px 6px rgba(0,0,0,0.05);
-  position: sticky;
-  top: 0;
-  z-index: 100;
-}
-
-.nav-right button {
-  margin-left: 0.75rem;       /* space between each button */
-  padding: 0.5rem 0.75rem;
-  font-size: 0.9rem;
-  border: 1px solid #362f2f;
-  background: #362f2f;
-  border-radius: 4px;
-  cursor: pointer;
-  color: #ffffff;
-}
-
-.nav-right button:hover {
-  background: #221e1e;
-}
-
-.app-title {
-  font-size: 1.25rem;
-  font-weight: bold;
-  color: #fbf8f8;
-}
-
-/* center form under header */
+/* center form */
 .signup-container {
   display: flex;
   align-items: center;

--- a/elearning-frontend/pages/signup.html
+++ b/elearning-frontend/pages/signup.html
@@ -7,16 +7,6 @@
   <link rel="stylesheet" href="../assets/css/signup.css">
 </head>
 <body>
-  <!-- Header -->
-  <header class="site-header">
-  <div class="app-title">
-    eLearning 
-  </div>
-  <nav class="nav-right">
-    <button onclick="location.href='login.html'">Login</button>
-  </nav>
-</header>
-
   <!-- Sign Up Form -->
   <main class="signup-container">
     <div class="form-card">


### PR DESCRIPTION
## Summary
- remove header block from signup page so users go straight to sign up form
- drop header-specific styles and center form styling in signup CSS

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68941f2b75988323900cc6feecbea0d7