### PR TITLE
feat: redesign dashboard layout

### DIFF
--- a/elearning-frontend/assets/css/dashboard.css
+++ b/elearning-frontend/assets/css/dashboard.css
@@ -14,39 +14,85 @@ body {
     color: #333;
 }
 
+/* Layout and Sidebar */
+.layout {
+    display: flex;
+    min-height: 100vh;
+}
+
+.sidebar {
+    width: 220px;
+    background: var(--primary-color);
+    color: white;
+    display: flex;
+    flex-direction: column;
+    padding: 20px 0;
+}
+
+.sidebar-logo {
+    font-weight: bold;
+    font-size: 22px;
+    color: var(--accent-color);
+    padding: 0 20px 20px;
+}
+
+.sidebar-nav {
+    display: flex;
+    flex-direction: column;
+}
+
+.sidebar-nav a {
+    color: #9ca3af;
+    padding: 12px 20px;
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.sidebar-nav a.active,
+.sidebar-nav a:hover {
+    background-color: #374151;
+    color: #fff;
+}
+
+.sidebar-nav a i {
+    margin-right: 10px;
+}
+
+.main {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+
 /* Header Styling */
 .header {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    background: linear-gradient(90deg, var(--primary-color), #111827); /* Dark navy gradient */
-    color: white;
+    background: #fff;
+    color: var(--primary-color);
     padding: 15px 30px;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.05);
 }
 
-.logo {
-    font-weight: bold;
-    font-size: 22px;
-    color: var(--accent-color); /* Accent orange */
+.page-title {
+    font-weight: 600;
+    font-size: 20px;
 }
 
-.header nav a {
-    color: white;
-    margin-left: 20px;
+.header-actions a {
+    color: var(--primary-color);
+    margin-left: 15px;
     text-decoration: none;
-    font-weight: 500;
 }
 
-.header nav a:hover {
+.header-actions a:hover {
     color: var(--accent-color);
 }
 
 /* Main Content */
 main {
     padding: 30px;
-    max-width: 1200px;
-    margin: 0 auto;
 }
 
 h2 {
@@ -114,6 +160,39 @@ h2 {
 
 .info-list p:last-child {
     border-bottom: none;
+}
+
+/* Stats Section */
+.stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 20px;
+    margin-bottom: 30px;
+}
+
+.stat-card {
+    background: var(--accent-color);
+    color: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+}
+
+.stat-card i {
+    font-size: 28px;
+    margin-right: 15px;
+}
+
+.stat-title {
+    font-size: 0.9rem;
+    opacity: 0.9;
+}
+
+.stat-value {
+    font-size: 1.4rem;
+    font-weight: 700;
 }
 
 /* Buttons (shared for navigation and other pages) */

--- a/elearning-frontend/pages/dashboard.html
+++ b/elearning-frontend/pages/dashboard.html
@@ -12,33 +12,70 @@
 
 </head>
 <body>
-    <header class="header">
-        <div class="logo">eLearnHub</div>
-        <nav>
-            <a href="navigation.html">Navigation</a>
-            <a href="profile.html">Profile</a>
-            <a href="#" id="logout">Logout</a>
-        </nav>
-    </header>
+    <div class="layout">
+        <aside class="sidebar">
+            <div class="sidebar-logo">eLearnHub</div>
+            <nav class="sidebar-nav">
+                <a href="dashboard.html" class="active"><i class="fas fa-home"></i> Dashboard</a>
+                <a href="materials.html"><i class="fas fa-book"></i> Materials</a>
+                <a href="assignments.html"><i class="fas fa-tasks"></i> Assignments</a>
+                <a href="live.html"><i class="fas fa-video"></i> Live</a>
+                <a href="communication.html"><i class="fas fa-comments"></i> Communication</a>
+                <a href="profile.html"><i class="fas fa-user"></i> Profile</a>
+                <a href="navigation.html"><i class="fas fa-compass"></i> Navigation</a>
+            </nav>
+        </aside>
+        <div class="main">
+            <header class="header">
+                <div class="page-title">Dashboard</div>
+                <div class="header-actions">
+                    <a href="#" id="logout" title="Logout"><i class="fas fa-sign-out-alt"></i></a>
+                </div>
+            </header>
+            <main>
+                <section class="stats">
+                    <div class="stat-card">
+                        <i class="fas fa-book-open"></i>
+                        <div>
+                            <div class="stat-title">Enrolled Courses</div>
+                            <div class="stat-value" id="statCourses">0</div>
+                        </div>
+                    </div>
+                    <div class="stat-card">
+                        <i class="fas fa-check-circle"></i>
+                        <div>
+                            <div class="stat-title">Completed Tasks</div>
+                            <div class="stat-value" id="statCompleted">0</div>
+                        </div>
+                    </div>
+                    <div class="stat-card">
+                        <i class="fas fa-clock"></i>
+                        <div>
+                            <div class="stat-title">Pending Tasks</div>
+                            <div class="stat-value" id="statPending">0</div>
+                        </div>
+                    </div>
+                </section>
 
-    <main>
-        <h2 id="welcomeMessage">Welcome, Student!</h2>
+                <h2 id="welcomeMessage">Welcome, Student!</h2>
 
-        <div class="dashboard-grid">
-            <div class="card">
-                <h3><i class="fas fa-chalkboard-teacher"></i> My Classes</h3>
-                <div id="classesContainer" class="classes-container"></div>
-            </div>
-            <div class="card">
-                <h3><i class="fas fa-bullhorn"></i> Announcements</h3>
-                <div id="announcementsContainer" class="info-list"></div>
-            </div>
-            <div class="card">
-                <h3><i class="fas fa-calendar-alt"></i> Upcoming tasks and deadlines</h3>
-                <div id="tasksContainer" class="info-list"></div>
-            </div>
+                <div class="dashboard-grid">
+                    <div class="card">
+                        <h3><i class="fas fa-chalkboard-teacher"></i> My Classes</h3>
+                        <div id="classesContainer" class="classes-container"></div>
+                    </div>
+                    <div class="card">
+                        <h3><i class="fas fa-bullhorn"></i> Announcements</h3>
+                        <div id="announcementsContainer" class="info-list"></div>
+                    </div>
+                    <div class="card">
+                        <h3><i class="fas fa-calendar-alt"></i> Upcoming tasks and deadlines</h3>
+                        <div id="tasksContainer" class="info-list"></div>
+                    </div>
+                </div>
+            </main>
         </div>
-    </main>
+    </div>
 
     <!-- Modal for editing class -->
     <div id="classModal" class="modal">


### PR DESCRIPTION
## Summary
- Introduce sidebar navigation and top header for dashboard
- Add statistic cards for quick course and task overviews

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689484f6c80083239bcf395b6bbc2e93