### PR TITLE
Unify frontend pages with shared sidebar layout

### DIFF
--- a/elearning-frontend/assets/js/sidebar.js
+++ b/elearning-frontend/assets/js/sidebar.js
@@ -1,0 +1,14 @@
+async function loadSidebar() {
+    const sidebar = document.getElementById('sidebar');
+    if (!sidebar) return;
+    const res = await fetch('../components/sidebar.html');
+    sidebar.innerHTML = await res.text();
+    const path = window.location.pathname.split('/').pop();
+    sidebar.querySelectorAll('.sidebar-nav a').forEach(link => {
+        if (link.getAttribute('href') === path) {
+            link.classList.add('active');
+        }
+    });
+}
+
+document.addEventListener('DOMContentLoaded', loadSidebar);

--- a/elearning-frontend/components/sidebar.html
+++ b/elearning-frontend/components/sidebar.html
@@ -1,0 +1,10 @@
+<div class="sidebar-logo">eLearnHub</div>
+<nav class="sidebar-nav">
+    <a href="dashboard.html"><i class="fas fa-home"></i> Dashboard</a>
+    <a href="materials.html"><i class="fas fa-book"></i> Materials</a>
+    <a href="assignments.html"><i class="fas fa-tasks"></i> Assignments</a>
+    <a href="live.html"><i class="fas fa-video"></i> Live</a>
+    <a href="communication.html"><i class="fas fa-comments"></i> Communication</a>
+    <a href="profile.html"><i class="fas fa-user"></i> Profile</a>
+    <a href="navigation.html"><i class="fas fa-compass"></i> Navigation</a>
+</nav>

--- a/elearning-frontend/pages/assignments.html
+++ b/elearning-frontend/pages/assignments.html
@@ -4,55 +4,61 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Assignments</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer"/>
     <link rel="stylesheet" href="../assets/css/dashboard.css">
     <link rel="stylesheet" href="../assets/css/assignments.css">
 </head>
 <body>
-    <header class="header">
-        <div class="logo">eLearnHub</div>
-        <nav>
-            <a href="navigation.html">Navigation</a>
-            <a href="profile.html">Profile</a>
-            <a href="#" id="logout">Logout</a>
-        </nav>
-    </header>
+    <div class="layout">
+        <aside id="sidebar" class="sidebar"></aside>
+        <div class="main">
+            <header class="header">
+                <div class="page-title">Assignments</div>
+                <div class="header-actions">
+                    <a href="#" id="logout" title="Logout"><i class="fas fa-sign-out-alt"></i></a>
+                </div>
+            </header>
+            <main class="assignment-page">
+                <section class="page-header">
+                    <h2>Assignment Management</h2>
+                    <div class="course-selector">
+                        <label for="classSelect">Select Class:</label>
+                        <select id="classSelect">
+                            <option value="">-- Choose a Class --</option>
+                        </select>
+                    </div>
+                </section>
 
-    <main class="assignment-page">
-        <section class="page-header">
-            <h2>Assignment Management</h2>
-            <div class="course-selector">
-                <label for="classSelect">Select Class:</label>
-                <select id="classSelect">
-                    <option value="">-- Choose a Class --</option>
-                </select>
-            </div>
-        </section>
+                <section class="create-assignment" style="display:none;">
+                    <h3>Create Assignment</h3>
+                    <div class="form-grid">
+                        <div class="form-control">
+                            <label for="assnTitle">Title</label>
+                            <input type="text" id="assnTitle" placeholder="Assignment Title">
+                        </div>
+                        <div class="form-control">
+                            <label for="assnDesc">Description</label>
+                            <textarea id="assnDesc" placeholder="Description"></textarea>
+                        </div>
+                        <div class="form-control">
+                            <label for="assnDue">Due Date</label>
+                            <input type="date" id="assnDue">
+                        </div>
+                        <div class="form-control">
+                            <label for="assnResource">Resource</label>
+                            <input type="file" id="assnResource">
+                        </div>
+                    </div>
+                    <button id="createAssnBtn">Create</button>
+                </section>
 
-        <section class="create-assignment" style="display:none;">
-            <h3>Create Assignment</h3>
-            <div class="form-grid">
-                <div class="form-control">
-                    <label for="assnTitle">Title</label>
-                    <input type="text" id="assnTitle" placeholder="Assignment Title">
-                </div>
-                <div class="form-control">
-                    <label for="assnDesc">Description</label>
-                    <textarea id="assnDesc" placeholder="Description"></textarea>
-                </div>
-                <div class="form-control">
-                    <label for="assnDue">Due Date</label>
-                    <input type="date" id="assnDue">
-                </div>
-                <div class="form-control">
-                    <label for="assnResource">Resource</label>
-                    <input type="file" id="assnResource">
-                </div>
-            </div>
-            <button id="createAssnBtn">Create</button>
-        </section>
-
-        <section id="assignmentList" class="assignment-list"></section>
-    </main>
+                <section id="assignmentList" class="assignment-list"></section>
+            </main>
+        </div>
+    </div>
 
     <!-- Modal for submitting assignment -->
     <div id="submitModal" class="modal">
@@ -64,6 +70,7 @@
         </div>
     </div>
 
+    <script src="../assets/js/sidebar.js"></script>
     <script src="../assets/js/assignments.js"></script>
 </body>
 </html>

--- a/elearning-frontend/pages/communication.html
+++ b/elearning-frontend/pages/communication.html
@@ -4,55 +4,62 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Communication & Notifications</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer"/>
     <link rel="stylesheet" href="../assets/css/dashboard.css">
     <link rel="stylesheet" href="../assets/css/communication.css">
 </head>
 <body>
-    <header class="header">
-        <div class="logo">eLearnHub</div>
-        <nav>
-            <a href="navigation.html">Navigation</a>
-            <a href="profile.html">Profile</a>
-            <a href="#" id="logout">Logout</a>
-        </nav>
-    </header>
+    <div class="layout">
+        <aside id="sidebar" class="sidebar"></aside>
+        <div class="main">
+            <header class="header">
+                <div class="page-title">Communication</div>
+                <div class="header-actions">
+                    <a href="#" id="logout" title="Logout"><i class="fas fa-sign-out-alt"></i></a>
+                </div>
+            </header>
+            <main class="communication-page">
+                <section class="page-header">
+                    <h2>Communication & Notifications</h2>
+                    <div class="course-selector">
+                        <label for="courseSelect">Select Course:</label>
+                        <select id="courseSelect">
+                            <option value="">-- Choose a Course --</option>
+                        </select>
+                    </div>
+                </section>
 
-    <main class="communication-page">
-        <section class="page-header">
-            <h2>Communication & Notifications</h2>
-            <div class="course-selector">
-                <label for="courseSelect">Select Course:</label>
-                <select id="courseSelect">
-                    <option value="">-- Choose a Course --</option>
-                </select>
-            </div>
-        </section>
+                <section class="announce-section" style="display:none;">
+                    <h3>Announcements</h3>
+                    <form id="announceForm">
+                        <textarea id="announceMessage" placeholder="Write announcement"></textarea>
+                        <button type="submit">Post Announcement</button>
+                    </form>
+                    <div id="announcementsList"></div>
+                </section>
 
-        <section class="announce-section" style="display:none;">
-            <h3>Announcements</h3>
-            <form id="announceForm">
-                <textarea id="announceMessage" placeholder="Write announcement"></textarea>
-                <button type="submit">Post Announcement</button>
-            </form>
-            <div id="announcementsList"></div>
-        </section>
+                <section class="thread-section" style="display:none;">
+                    <h3>Discussion Threads</h3>
+                    <form id="threadForm">
+                        <input type="text" id="threadTitle" placeholder="Thread title">
+                        <textarea id="threadContent" placeholder="Start a discussion"></textarea>
+                        <button type="submit">Start Thread</button>
+                    </form>
+                    <div id="threadsList"></div>
+                </section>
 
-        <section class="thread-section" style="display:none;">
-            <h3>Discussion Threads</h3>
-            <form id="threadForm">
-                <input type="text" id="threadTitle" placeholder="Thread title">
-                <textarea id="threadContent" placeholder="Start a discussion"></textarea>
-                <button type="submit">Start Thread</button>
-            </form>
-            <div id="threadsList"></div>
-        </section>
+                <section class="notification-section" style="display:none;">
+                    <h3>Notifications</h3>
+                    <div id="notificationList"></div>
+                </section>
+            </main>
+        </div>
+    </div>
 
-        <section class="notification-section" style="display:none;">
-            <h3>Notifications</h3>
-            <div id="notificationList"></div>
-        </section>
-    </main>
-
+    <script src="../assets/js/sidebar.js"></script>
     <script src="../assets/js/communication.js"></script>
 </body>
 </html>

--- a/elearning-frontend/pages/dashboard.html
+++ b/elearning-frontend/pages/dashboard.html
@@ -13,18 +13,7 @@
 </head>
 <body>
     <div class="layout">
-        <aside class="sidebar">
-            <div class="sidebar-logo">eLearnHub</div>
-            <nav class="sidebar-nav">
-                <a href="dashboard.html" class="active"><i class="fas fa-home"></i> Dashboard</a>
-                <a href="materials.html"><i class="fas fa-book"></i> Materials</a>
-                <a href="assignments.html"><i class="fas fa-tasks"></i> Assignments</a>
-                <a href="live.html"><i class="fas fa-video"></i> Live</a>
-                <a href="communication.html"><i class="fas fa-comments"></i> Communication</a>
-                <a href="profile.html"><i class="fas fa-user"></i> Profile</a>
-                <a href="navigation.html"><i class="fas fa-compass"></i> Navigation</a>
-            </nav>
-        </aside>
+        <aside id="sidebar" class="sidebar"></aside>
         <div class="main">
             <header class="header">
                 <div class="page-title">Dashboard</div>
@@ -88,6 +77,7 @@
         </div>
     </div>
 
+    <script src="../assets/js/sidebar.js"></script>
     <script src="../assets/js/main.js"></script>
 </body>
 </html>

--- a/elearning-frontend/pages/live.html
+++ b/elearning-frontend/pages/live.html
@@ -12,46 +12,51 @@
     <link rel="stylesheet" href="../assets/css/live.css">
 </head>
 <body>
-    <header class="header">
-        <div class="logo">eLearnHub</div>
-        <nav>
-            <a href="navigation.html">Navigation</a>
-            <a href="profile.html">Profile</a>
-            <a href="#" id="logout">Logout</a>
-        </nav>
-    </header>
-    <main>
-        <h2>Live Lectures</h2>
-        <div class="live-grid">
-            <div class="card">
-                <h3><i class="fas fa-calendar-plus"></i> Schedule Lecture</h3>
-                <form id="scheduleForm" class="live-form">
-                    <input type="text" id="lectureTitle" placeholder="Title" required>
-                    <input type="datetime-local" id="lectureTime" required>
-                    <button type="submit">Schedule</button>
-                </form>
-            </div>
-            <div class="card">
-                <h3><i class="fas fa-door-open"></i> Join Lecture</h3>
-                <form id="joinForm" class="live-form">
-                    <input type="number" id="lectureId" placeholder="Lecture ID" required>
-                    <button type="submit">Join</button>
-                </form>
-            </div>
-            <div class="card">
-                <h3><i class="fas fa-share-square"></i> Share Screen</h3>
-                <form id="shareForm" class="live-form">
-                    <input type="number" id="shareLectureId" placeholder="Lecture ID" required>
-                    <button type="submit">Share Screen</button>
-                </form>
-            </div>
-            <div class="card">
-                <h3><i class="fas fa-chart-bar"></i> Analytics</h3>
-                <button id="refreshAnalytics">Refresh</button>
-                <pre id="analyticsOutput" class="analytics-output"></pre>
-            </div>
+    <div class="layout">
+        <aside id="sidebar" class="sidebar"></aside>
+        <div class="main">
+            <header class="header">
+                <div class="page-title">Live Lectures</div>
+                <div class="header-actions">
+                    <a href="#" id="logout" title="Logout"><i class="fas fa-sign-out-alt"></i></a>
+                </div>
+            </header>
+            <main>
+                <h2>Live Lectures</h2>
+                <div class="live-grid">
+                    <div class="card">
+                        <h3><i class="fas fa-calendar-plus"></i> Schedule Lecture</h3>
+                        <form id="scheduleForm" class="live-form">
+                            <input type="text" id="lectureTitle" placeholder="Title" required>
+                            <input type="datetime-local" id="lectureTime" required>
+                            <button type="submit">Schedule</button>
+                        </form>
+                    </div>
+                    <div class="card">
+                        <h3><i class="fas fa-door-open"></i> Join Lecture</h3>
+                        <form id="joinForm" class="live-form">
+                            <input type="number" id="lectureId" placeholder="Lecture ID" required>
+                            <button type="submit">Join</button>
+                        </form>
+                    </div>
+                    <div class="card">
+                        <h3><i class="fas fa-share-square"></i> Share Screen</h3>
+                        <form id="shareForm" class="live-form">
+                            <input type="number" id="shareLectureId" placeholder="Lecture ID" required>
+                            <button type="submit">Share Screen</button>
+                        </form>
+                    </div>
+                    <div class="card">
+                        <h3><i class="fas fa-chart-bar"></i> Analytics</h3>
+                        <button id="refreshAnalytics">Refresh</button>
+                        <pre id="analyticsOutput" class="analytics-output"></pre>
+                    </div>
+                </div>
+            </main>
         </div>
-    </main>
+    </div>
+
+    <script src="../assets/js/sidebar.js"></script>
     <script src="../assets/js/live.js"></script>
 </body>
 </html>

--- a/elearning-frontend/pages/materials.html
+++ b/elearning-frontend/pages/materials.html
@@ -12,47 +12,50 @@
     <link rel="stylesheet" href="../assets/css/materials.css">
 </head>
 <body>
-    <header class="header">
-        <div class="logo">eLearnHub</div>
-        <nav>
-            <a href="navigation.html">Navigation</a>
-            <a href="profile.html">Profile</a>
-            <a href="#" id="logout">Logout</a>
-        </nav>
-    </header>
+    <div class="layout">
+        <aside id="sidebar" class="sidebar"></aside>
+        <div class="main">
+            <header class="header">
+                <div class="page-title">Materials</div>
+                <div class="header-actions">
+                    <a href="#" id="logout" title="Logout"><i class="fas fa-sign-out-alt"></i></a>
+                </div>
+            </header>
+            <main>
+                <section class="materials-hero">
+                    <div class="hero-content">
+                        <h1><i class="fas fa-book-open"></i> Course Materials</h1>
+                        <p>Access, upload and manage resources for your classes.</p>
+                    </div>
+                </section>
 
-    <section class="materials-hero">
-        <div class="hero-content">
-            <h1><i class="fas fa-book-open"></i> Course Materials</h1>
-            <p>Access, upload and manage resources for your classes.</p>
+                <div class="course-selector">
+                    <label for="courseSelect"><i class="fas fa-chalkboard"></i> Select Course:</label>
+                    <select id="courseSelect">
+                        <option value="">-- Choose a Course --</option>
+                    </select>
+                </div>
+
+                <div class="upload-section" style="display: none;">
+                    <h3><i class="fas fa-upload"></i> Upload Material</h3>
+                    <form id="uploadForm">
+                        <input type="text" name="title" id="title" placeholder="Title" required>
+                        <input type="text" name="folder" id="folder" placeholder="Folder (e.g. Week 1)">
+                        <input type="text" name="tags" id="tags" placeholder="Tags (comma separated)">
+                        <input type="file" name="file" id="file" required>
+                        <button type="submit">Upload</button>
+                    </form>
+                </div>
+
+                <div class="materials-list" style="display: none;">
+                    <h3><i class="fas fa-folder-open"></i> Available Materials</h3>
+                    <div id="materialsContainer"></div>
+                </div>
+            </main>
         </div>
-    </section>
+    </div>
 
-    <main>
-        <div class="course-selector">
-            <label for="courseSelect"><i class="fas fa-chalkboard"></i> Select Course:</label>
-            <select id="courseSelect">
-                <option value="">-- Choose a Course --</option>
-            </select>
-        </div>
-
-        <div class="upload-section" style="display: none;">
-            <h3><i class="fas fa-upload"></i> Upload Material</h3>
-            <form id="uploadForm">
-                <input type="text" name="title" id="title" placeholder="Title" required>
-                <input type="text" name="folder" id="folder" placeholder="Folder (e.g. Week 1)">
-                <input type="text" name="tags" id="tags" placeholder="Tags (comma separated)">
-                <input type="file" name="file" id="file" required>
-                <button type="submit">Upload</button>
-            </form>
-        </div>
-
-        <div class="materials-list" style="display: none;">
-            <h3><i class="fas fa-folder-open"></i> Available Materials</h3>
-            <div id="materialsContainer"></div>
-        </div>
-    </main>
-
+    <script src="../assets/js/sidebar.js"></script>
     <script src="../assets/js/materials.js"></script>
 </body>
 </html>

--- a/elearning-frontend/pages/navigation.html
+++ b/elearning-frontend/pages/navigation.html
@@ -11,44 +11,46 @@
     <link rel="stylesheet" href="../assets/css/dashboard.css">
 </head>
 <body>
-    <header class="header">
-        <div class="logo">eLearnHub</div>
-        <nav>
-            <a href="dashboard.html">Dashboard</a>
-            <a href="profile.html">Profile</a>
-            <a href="#" id="logout">Logout</a>
-        </nav>
-    </header>
-
-    <main class="nav-main">
-        <h2>Choose an Option</h2>
-        <div class="nav-grid">
-            <div class="nav-card" id="openJoin">
-                <i class="fas fa-user-plus"></i>
-                <h3>Join Class</h3>
-            </div>
-            <div class="nav-card" id="openCreate">
-                <i class="fas fa-plus-circle"></i>
-                <h3>Create Class</h3>
-            </div>
-            <div class="nav-card" id="openMaterials">
-                <i class="fas fa-book-open"></i>
-                <h3>Course Materials</h3>
-            </div>
-            <div class="nav-card" id="openAssignments">
-                <i class="fas fa-tasks"></i>
-                <h3>Assignments</h3>
-            </div>
-            <div class="nav-card" id="openCommunication">
-                <i class="fas fa-comments"></i>
-                <h3>Communication</h3>
-            </div>
-            <div class="nav-card" id="openLive">
-                <i class="fas fa-video"></i>
-                <h3>Live Lectures</h3>
-            </div>
+    <div class="layout">
+        <aside id="sidebar" class="sidebar"></aside>
+        <div class="main">
+            <header class="header">
+                <div class="page-title">Navigation</div>
+                <div class="header-actions">
+                    <a href="#" id="logout" title="Logout"><i class="fas fa-sign-out-alt"></i></a>
+                </div>
+            </header>
+            <main class="nav-main">
+                <h2>Choose an Option</h2>
+                <div class="nav-grid">
+                    <div class="nav-card" id="openJoin">
+                        <i class="fas fa-user-plus"></i>
+                        <h3>Join Class</h3>
+                    </div>
+                    <div class="nav-card" id="openCreate">
+                        <i class="fas fa-plus-circle"></i>
+                        <h3>Create Class</h3>
+                    </div>
+                    <div class="nav-card" id="openMaterials">
+                        <i class="fas fa-book-open"></i>
+                        <h3>Course Materials</h3>
+                    </div>
+                    <div class="nav-card" id="openAssignments">
+                        <i class="fas fa-tasks"></i>
+                        <h3>Assignments</h3>
+                    </div>
+                    <div class="nav-card" id="openCommunication">
+                        <i class="fas fa-comments"></i>
+                        <h3>Communication</h3>
+                    </div>
+                    <div class="nav-card" id="openLive">
+                        <i class="fas fa-video"></i>
+                        <h3>Live Lectures</h3>
+                    </div>
+                </div>
+            </main>
         </div>
-    </main>
+    </div>
 
     <!-- Join Class Modal -->
     <div id="joinModal" class="modal">
@@ -75,6 +77,7 @@
         </div>
     </div>
 
+    <script src="../assets/js/sidebar.js"></script>
     <script src="../assets/js/navigation.js"></script>
 </body>
 </html>

--- a/elearning-frontend/pages/profile.html
+++ b/elearning-frontend/pages/profile.html
@@ -4,44 +4,52 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Profile</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer"/>
   <link rel="stylesheet" href="../assets/css/dashboard.css">
   <link rel="stylesheet" href="../assets/css/profile.css">
 </head>
 <body>
-  <header class="header">
-    <div class="logo">eLearnHub</div>
-    <nav>
-      <a href="navigation.html">Navigation</a>
-      <a href="#" id="logout">Logout</a>
-    </nav>
-  </header>
+  <div class="layout">
+    <aside id="sidebar" class="sidebar"></aside>
+    <div class="main">
+      <header class="header">
+        <div class="page-title">Profile</div>
+        <div class="header-actions">
+          <a href="#" id="logout" title="Logout"><i class="fas fa-sign-out-alt"></i></a>
+        </div>
+      </header>
+      <main class="profile-page">
+        <section class="profile-section">
+          <h2>Profile Information</h2>
+          <form id="profileForm">
+            <label for="name">Name</label>
+            <input type="text" id="name" required>
+            <label for="email">Email</label>
+            <input type="email" id="email" required>
+            <button type="submit">Update Profile</button>
+            <p id="profileMsg" class="msg"></p>
+          </form>
+        </section>
 
-  <main class="profile-page">
-    <section class="profile-section">
-      <h2>Profile Information</h2>
-      <form id="profileForm">
-        <label for="name">Name</label>
-        <input type="text" id="name" required>
-        <label for="email">Email</label>
-        <input type="email" id="email" required>
-        <button type="submit">Update Profile</button>
-        <p id="profileMsg" class="msg"></p>
-      </form>
-    </section>
+        <section class="password-section">
+          <h2>Change Password</h2>
+          <form id="passwordForm">
+            <label for="currentPassword">Current Password</label>
+            <input type="password" id="currentPassword" required>
+            <label for="newPassword">New Password</label>
+            <input type="password" id="newPassword" required>
+            <button type="submit">Change Password</button>
+            <p id="passwordMsg" class="msg"></p>
+          </form>
+        </section>
+      </main>
+    </div>
+  </div>
 
-    <section class="password-section">
-      <h2>Change Password</h2>
-      <form id="passwordForm">
-        <label for="currentPassword">Current Password</label>
-        <input type="password" id="currentPassword" required>
-        <label for="newPassword">New Password</label>
-        <input type="password" id="newPassword" required>
-        <button type="submit">Change Password</button>
-        <p id="passwordMsg" class="msg"></p>
-      </form>
-    </section>
-  </main>
-
+  <script src="../assets/js/sidebar.js"></script>
   <script src="../assets/js/profile.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add reusable sidebar component and loader script
- Switch internal pages to unified layout with sidebar and page titles

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `cd backend && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689487920c3c83239ffadc63d21d509e