### PR TITLE
Implement dashboard statistics

### DIFF
--- a/backend/routes/analytics.js
+++ b/backend/routes/analytics.js
@@ -3,7 +3,17 @@ const router = express.Router();
 const jwt = require('jsonwebtoken');
 require('dotenv').config();
 
+const db = require('../config/db');
 const { lectures } = require('../models/lectureStore');
+
+function query(sql, params) {
+  return new Promise((resolve, reject) => {
+    db.query(sql, params, (err, results) => {
+      if (err) reject(err);
+      else resolve(results);
+    });
+  });
+}
 
 function authenticateToken(req, res, next) {
   const authHeader = req.headers['authorization'];
@@ -22,6 +32,38 @@ router.get('/lectures', authenticateToken, (req, res) => {
   const participants = lectures.reduce((sum, l) => sum + l.participants.length, 0);
   const screenShares = lectures.filter(l => l.screenShared).length;
   res.json({ scheduled, participants, screenShares });
+});
+
+// Dashboard statistics for a logged-in student
+router.get('/dashboard', authenticateToken, async (req, res) => {
+  try {
+    const userId = req.user.user_id;
+
+    const courses = await query(
+      "SELECT COUNT(*) AS count FROM enrollments WHERE student_id = ? AND status = 'approved'",
+      [userId]
+    );
+
+    const taskCounts = await query(
+      `SELECT 
+         SUM(CASE WHEN s.submission_id IS NOT NULL THEN 1 ELSE 0 END) AS completed,
+         SUM(CASE WHEN s.submission_id IS NULL THEN 1 ELSE 0 END) AS pending
+       FROM assignments a
+       JOIN enrollments e ON a.class_id = e.class_id
+       LEFT JOIN submissions s ON a.assignment_id = s.assignment_id AND s.student_id = e.student_id
+       WHERE e.student_id = ? AND e.status = 'approved'`,
+      [userId]
+    );
+
+    const enrolledCourses = courses[0]?.count || 0;
+    const completedTasks = taskCounts[0]?.completed || 0;
+    const pendingTasks = taskCounts[0]?.pending || 0;
+
+    res.json({ enrolledCourses, completedTasks, pendingTasks });
+  } catch (err) {
+    console.error('Dashboard analytics error:', err);
+    res.status(500).json({ message: 'Server error', error: err });
+  }
 });
 
 module.exports = router;

--- a/elearning-frontend/assets/js/main.js
+++ b/elearning-frontend/assets/js/main.js
@@ -15,6 +15,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const container = document.getElementById('classesContainer');
   const annContainer = document.getElementById('announcementsContainer');
   const tasksContainer = document.getElementById('tasksContainer');
+  const statCourses = document.getElementById('statCourses');
+  const statCompleted = document.getElementById('statCompleted');
+  const statPending = document.getElementById('statPending');
   const modal = document.getElementById('classModal');
   const modalTitle = document.getElementById('modalTitle');
   const modalDescription = document.getElementById('modalDescription');
@@ -50,6 +53,24 @@ document.addEventListener('DOMContentLoaded', () => {
       alert(err.message);
     }
   });
+
+  async function loadStats() {
+    if (!statCourses && !statCompleted && !statPending) return;
+    try {
+      const res = await fetch('/api/analytics/dashboard', {
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.message || 'Failed to load stats');
+      if (statCourses) statCourses.textContent = data.enrolledCourses;
+      if (statCompleted) statCompleted.textContent = data.completedTasks;
+      if (statPending) statPending.textContent = data.pendingTasks;
+    } catch (_) {
+      if (statCourses) statCourses.textContent = '0';
+      if (statCompleted) statCompleted.textContent = '0';
+      if (statPending) statPending.textContent = '0';
+    }
+  }
 
   async function loadClasses() {
     container.innerHTML = '';
@@ -275,6 +296,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   loadClasses();
+  loadStats();
 
   const logout = document.getElementById('logout');
   if (logout) {


### PR DESCRIPTION
## Summary
- add backend analytics endpoint to count enrolled courses and assignment statuses for logged-in students
- load dashboard stats on frontend and display enrolled courses, completed tasks, and pending tasks

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68948fbaf610832395fd9060bbd76acc