### PR TITLE
Add analytics route tests and fix user tests

### DIFF
--- a/backend/tests/analytics.test.js
+++ b/backend/tests/analytics.test.js
@@ -1,0 +1,46 @@
+const request = require('supertest');
+const express = require('express');
+const jwt = require('jsonwebtoken');
+
+// Import router and lecture store
+const analyticsRouter = require('../routes/analytics');
+const { lectures } = require('../models/lectureStore');
+
+// Mock JWT verification
+jest.mock('jsonwebtoken', () => ({
+  verify: jest.fn(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/analytics', analyticsRouter);
+
+const token = 'fake-token';
+
+describe('Analytics Routes', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    lectures.length = 0; // reset in-memory store
+  });
+
+  it('should return 401 if no token provided', async () => {
+    const res = await request(app).get('/analytics/lectures');
+    expect(res.status).toBe(401);
+    expect(res.body.message).toBe('No token provided.');
+  });
+
+  it('should return lecture analytics', async () => {
+    jwt.verify.mockImplementation((token, secret, cb) => cb(null, { user_id: 1 }));
+
+    // Seed lecture data
+    lectures.push({ participants: ['a', 'b'], screenShared: true });
+    lectures.push({ participants: ['c'], screenShared: false });
+
+    const res = await request(app)
+      .get('/analytics/lectures')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ scheduled: 2, participants: 3, screenShares: 1 });
+  });
+});

--- a/backend/tests/user.test.js
+++ b/backend/tests/user.test.js
@@ -67,7 +67,8 @@ describe('User Routes', () => {
         { user_id: 1, name: 'A', email: 'a@test.com', created_at: '2025-08-28' },
       ];
 
-      db.query.mockImplementationOnce((query, cb) => cb(null, users));
+      // db.query in user route uses a callback with signature (sql, params, cb)
+      db.query.mockImplementationOnce((query, params, cb) => cb(null, users));
 
       const res = await request(app).get('/api/user');
 


### PR DESCRIPTION
## Summary
- ensure user tests mock database query with correct callback signature
- add test coverage for analytics routes, including auth guard and lecture metrics

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68b805aa350883238e8fe735db45089e